### PR TITLE
fix: 元数据写入失败改为 fatal，结果页显示每 track 状态

### DIFF
--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -43,15 +43,23 @@ final class SplitterViewModel: ObservableObject {
         let albumTitle: String?
         let performer: String?
         let coverImageData: Data?
+        /// Whether cover art was embedded.
+        let coverEmbedded: Bool
+        /// Total tracks that had metadata successfully written.
+        let metadataSucceededCount: Int
+        /// Total tracks that failed metadata writing.
+        let metadataFailedCount: Int
+        /// Cover art fetch error if any.
+        let metadataFailures: [String]
 
         /// 从第一个 FLAC 文件读取封面图数据（Data?）。
-        static func readCover(from files: [URL]) -> Data? {
-            guard let firstTrack = files.first(where: { $0.pathExtension.lowercased() == "flac" }) else { return nil }
-            // 使用 mutagen 读取第一张封面，写入临时 PNG，读取后删除。
+        static func readCover(from files: [URL]) -> (data: Data?, pythonPath: String) {
+            guard let firstTrack = files.first(where: { $0.pathExtension.lowercased() == "flac" }) else {
+                return (nil, "")
+            }
             let tmpPath = NSTemporaryDirectory() + "ts_cover_\(UUID().uuidString).png"
             let script = """
 from mutagen.flac import FLAC
-import sys
 f = FLAC('\(firstTrack.path)')
 if f.pictures:
     open('\(tmpPath)', 'wb').write(f.pictures[0].data)
@@ -59,15 +67,19 @@ if f.pictures:
 else:
     print('NO_COVER')
 """
+            // Use the same python lookup as MetadataEmbedder
+            let candidates = ["/opt/homebrew/bin/python3", "/opt/homebrew/bin/python3.14", "/usr/local/bin/python3", "python3"]
+            let pythonPath = candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? "python3"
+
             let proc = Process()
-            proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+            proc.executableURL = URL(fileURLWithPath: pythonPath)
             proc.arguments = ["-c", script]
             try? proc.run()
             proc.waitUntilExit()
-            guard FileManager.default.fileExists(atPath: tmpPath) else { return nil }
+            guard FileManager.default.fileExists(atPath: tmpPath) else { return (nil, pythonPath) }
             let data = try? Data(contentsOf: URL(fileURLWithPath: tmpPath))
             try? FileManager.default.removeItem(atPath: tmpPath)
-            return data
+            return (data, pythonPath)
         }
     }
 
@@ -134,13 +146,17 @@ else:
             do {
                 let engine = TrackSplitterEngine(logHandler: handler)
                 let result = try await engine.process(flacURL: loaded.flacURL)
-                let coverData = Completion.readCover(from: result.trackFiles)
+                let (coverData, _) = Completion.readCover(from: result.trackFiles)
                 let completion = Completion(
                     outputDirectory: result.outputDirectory,
                     trackFiles: result.trackFiles,
                     albumTitle: result.albumTitle,
                     performer: result.performer,
-                    coverImageData: coverData
+                    coverImageData: coverData,
+                    coverEmbedded: result.coverEmbedded,
+                    metadataSucceededCount: result.metadataResult.succeeded,
+                    metadataFailedCount: result.metadataResult.failed,
+                    metadataFailures: result.metadataResult.failures
                 )
                 await MainActor.run {
                     self.progress = 1

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -360,11 +360,49 @@ struct ErrorView: View {
     }
 }
 
-// MARK: - ResultView & ProcessingView (已存在，确保引用 SplitterViewModel.Completion)
+// MARK: - ResultView
 struct ResultView: View {
     let result: SplitterViewModel.Completion
     let onShowInFinder: () -> Void
     let onProcessAnother: () -> Void
+
+    private var metadataStatusIcon: String {
+        if result.metadataFailedCount == 0 {
+            return "checkmark.circle.fill"
+        } else if result.metadataFailedCount < result.trackFiles.count {
+            return "exclamationmark.circle.fill"
+        } else {
+            return "xmark.circle.fill"
+        }
+    }
+
+    private var metadataStatusColor: Color {
+        if result.metadataFailedCount == 0 {
+            return .green
+        } else if result.metadataFailedCount < result.trackFiles.count {
+            return .orange
+        } else {
+            return .red
+        }
+    }
+
+    private var metadataStatusText: String {
+        if result.metadataFailedCount == 0 {
+            return "✅ 所有 \(result.metadataSucceededCount) 个曲目元数据写入成功"
+        } else if result.metadataFailedCount < result.trackFiles.count {
+            return "⚠️  \(result.metadataSucceededCount) 个成功，\(result.metadataFailedCount) 个失败"
+        } else {
+            return "❌ 元数据写入全部失败（\(result.metadataFailedCount) 个曲目）"
+        }
+    }
+
+    private var coverStatusText: String {
+        if result.coverEmbedded {
+            return "✅ 封面已嵌入"
+        } else {
+            return "⚠️  封面未获取"
+        }
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -418,6 +456,48 @@ struct ResultView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .lineLimit(2)
+                    }
+                }
+
+                Divider()
+
+                // 元数据状态
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        Image(systemName: metadataStatusIcon)
+                            .foregroundColor(metadataStatusColor)
+                        Text(metadataStatusText)
+                            .font(.subheadline)
+                            .foregroundColor(metadataStatusColor)
+                    }
+                    HStack(spacing: 8) {
+                        Image(systemName: result.coverEmbedded ? "photo.fill" : "photo")
+                            .foregroundColor(result.coverEmbedded ? .green : .orange)
+                        Text(coverStatusText)
+                            .font(.subheadline)
+                            .foregroundColor(result.coverEmbedded ? .green : .orange)
+                    }
+
+                    // 部分失败时显示错误列表
+                    if !result.metadataFailures.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("失败详情：")
+                                .font(.caption.bold())
+                                .foregroundStyle(.secondary)
+                            ForEach(result.metadataFailures.prefix(5), id: \.self) { failure in
+                                Text("• \(failure)")
+                                    .font(.caption)
+                                    .foregroundStyle(.red)
+                            }
+                            if result.metadataFailures.count > 5 {
+                                Text("• ...还有 \(result.metadataFailures.count - 5) 条")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(8)
+                        .background(Color.red.opacity(0.05))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
                     }
                 }
 

--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -21,6 +21,16 @@ public actor MetadataEmbedder {
         }
     }
 
+    public struct EmbedResult: Sendable {
+        public let total: Int
+        public let succeeded: Int
+        public let failed: Int
+        public let failures: [String]
+
+        public var isFullySuccessful: Bool { failed == 0 }
+        public var isPartiallySuccessful: Bool { succeeded > 0 && failed > 0 }
+    }
+
     private let pythonPath: String
     private let scriptPath: String
 
@@ -35,12 +45,11 @@ public actor MetadataEmbedder {
     }
 
     /// Walk up from the executable's directory to find embed_metadata.py.
-/// Handles SPM development builds, release builds, and installed layouts.
+    /// Handles SPM development builds, release builds, and installed layouts.
     private static func locateScript() -> String {
         let exeDir = (CommandLine.arguments.first.map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
             ?? FileManager.default.currentDirectoryPath)
 
-        // Build search paths using URL resolved against executable directory
         let exeURL = URL(fileURLWithPath: exeDir)
         let searchPaths: [URL] = [
             exeURL.appendingPathComponent("embed_metadata.py"),
@@ -57,10 +66,11 @@ public actor MetadataEmbedder {
             }
         }
 
-        return "embed_metadata.py"  // last resort: rely on PATH
+        return "embed_metadata.py"
     }
 
     /// Embed metadata into multiple FLAC files at once.
+    /// Returns a per-file result indicating success/failure for each track.
     public func embedBatch(
         files: [(url: URL, title: String, trackNumber: Int)],
         artist: String,
@@ -69,7 +79,7 @@ public actor MetadataEmbedder {
         genre: String,
         totalTracks: Int,
         coverData: Data?
-    ) async throws {
+    ) async throws -> EmbedResult {
         struct Item: Encodable {
             let path: String; let title: String; let artist: String
             let album: String; let year: String; let genre: String
@@ -98,11 +108,33 @@ public actor MetadataEmbedder {
         }
 
         defer { try? FileManager.default.removeItem(at: tempFile) }
-        try await runScript(jsonFile: tempFile)
+
+        let (stdout, stderr, rc) = try await runScript(jsonFile: tempFile)
+
+        // Parse per-file results from stdout
+        var succeeded = 0
+        var failed = 0
+        var failures: [String] = []
+
+        for line in stdout.components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
+            if line.hasPrefix("DONE: ") {
+                succeeded += 1
+            } else if line.hasPrefix("ERROR: ") {
+                failed += 1
+                failures.append(String(line.dropFirst(7)))
+            }
+        }
+
+        if rc != 0 && succeeded == 0 && failed == 0 {
+            failed = files.count
+            failures = ["脚本执行失败（RC=\(rc)）：\(stderr.prefix(100))"]
+        }
+
+        return EmbedResult(total: files.count, succeeded: succeeded, failed: failed, failures: failures)
     }
 
-    private func runScript(jsonFile: URL) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+    private func runScript(jsonFile: URL) async throws -> (stdout: String, stderr: String, rc: Int32) {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<(String, String, Int32), Error>) in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: pythonPath)
             process.arguments = [scriptPath, jsonFile.path]
@@ -121,13 +153,7 @@ public actor MetadataEmbedder {
                 let stdout = String(data: outData, encoding: .utf8) ?? ""
                 let stderr = String(data: errData, encoding: .utf8) ?? ""
 
-                if process.terminationStatus == 0 {
-                    cont.resume()
-                } else {
-                    cont.resume(throwing: EmbedError.scriptFailed(
-                        "RC=\(process.terminationStatus) STDERR=\(stderr.prefix(200)) STDOUT=\(stdout.prefix(100))"
-                    ))
-                }
+                cont.resume(returning: (stdout, stderr, process.terminationStatus))
             } catch {
                 cont.resume(throwing: error)
             }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -26,6 +26,10 @@ public actor TrackSplitterEngine {
         public let trackFiles: [URL]
         public let albumTitle: String?
         public let performer: String?
+        /// Whether cover art was successfully fetched and embedded.
+        public let coverEmbedded: Bool
+        /// Per-track metadata embedding result.
+        public let metadataResult: MetadataEmbedder.EmbedResult
     }
 
     public struct LogHandler: @unchecked Sendable {
@@ -99,10 +103,11 @@ public actor TrackSplitterEngine {
             throw EngineError.splittingFailed(error.localizedDescription)
         }
 
-        // 6. Embed metadata
+        // 6. Embed metadata (fatal on failure)
+        let metadataResult: MetadataEmbedder.EmbedResult
         log("🏷  Embedding metadata...")
         do {
-            try await embedder.embedBatch(
+            metadataResult = try await embedder.embedBatch(
                 files: zip(splitTracks, tracks).map { (url: $0.0, title: $0.1.title, trackNumber: $0.1.index) },
                 artist: performer ?? "Unknown Artist",
                 album: albumTitle ?? albumDirName,
@@ -111,13 +116,24 @@ public actor TrackSplitterEngine {
                 totalTracks: tracks.count,
                 coverData: coverData
             )
-            log("✅  Metadata embedded for all tracks")
+            if metadataResult.isFullySuccessful {
+                log("✅  Metadata embedded for all \(metadataResult.succeeded) tracks")
+            } else if metadataResult.isPartiallySuccessful {
+                log("⚠️  Metadata partially embedded: \(metadataResult.succeeded)/\(metadataResult.total) succeeded, \(metadataResult.failed) failed")
+            } else {
+                log("❌  Metadata embedding failed for all \(metadataResult.failed) tracks")
+                throw EngineError.metadataFailed(
+                    metadataResult.failures.joined(separator: "; ")
+                )
+            }
         } catch {
-            log("⚠️  Metadata embedding failed: \(error.localizedDescription)")
-            // Non-fatal — tracks were still split successfully
+            log("❌  Metadata embedding failed: \(error.localizedDescription)")
+            throw EngineError.metadataFailed(error.localizedDescription)
         }
 
         return Result(outputDirectory: outDir, trackFiles: splitTracks,
-                      albumTitle: albumTitle, performer: performer)
+                      albumTitle: albumTitle, performer: performer,
+                      coverEmbedded: coverData != nil,
+                      metadataResult: metadataResult)
     }
 }

--- a/Resources/embed_metadata.py
+++ b/Resources/embed_metadata.py
@@ -5,18 +5,18 @@ from mutagen.flac import FLAC, Picture
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: embed_metadata.py <json_file>", file=sys.stderr)
+        print("ERROR: Usage: embed_metadata.py <json_file>", file=sys.stderr)
         sys.exit(1)
 
     json_path = sys.argv[1]
     if not os.path.exists(json_path):
-        print("FILE_NOT_FOUND: %s" % json_path, file=sys.stderr)
+        print("ERROR: JSON file not found: %s" % json_path)
         sys.exit(1)
 
     try:
         payload = json.load(open(json_path))
     except Exception as e:
-        print("JSON load error: %s" % e, file=sys.stderr)
+        print("ERROR: JSON load error: %s" % e)
         sys.exit(1)
 
     cover_bytes = None
@@ -29,7 +29,7 @@ def main():
     for item in payload.get("files", []):
         fpath = item.get("path", "")
         if not os.path.exists(fpath):
-            print("FILE_NOT_FOUND: %s" % fpath, file=sys.stderr)
+            print("ERROR: %s: file not found" % os.path.basename(fpath))
             continue
 
         try:
@@ -57,7 +57,7 @@ def main():
             audio.save()
             print("DONE: %s" % os.path.basename(fpath))
         except Exception as e:
-            print("ERROR: %s: %s" % (os.path.basename(fpath), e), file=sys.stderr)
+            print("ERROR: %s: %s" % (os.path.basename(fpath), e))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 修复内容

### 问题
`MetadataEmbedder.embedBatch()` 失败时只打 warning 不阻断流程，用户以为拆分成功实际上元数据全部丢失（issue #1）。

### 改动

**Library/MetadataEmbedder.swift**
- `embedBatch()` 改为返回 `EmbedResult`（包含 total/succeeded/failed/failures）
- 解析 Python 脚本 stdout 中每行的 `DONE:` / `ERROR:` 前缀，精确统计每个 track 的写入结果

**Library/TrackSplitterEngine.swift**
- `Result` 新增 `coverEmbedded`、`metadataResult` 字段
- 元数据**完全失败**时抛出 `EngineError.metadataFailed`（fatal，整个处理失败）
- **部分成功**时继续完成，但在日志和结果中显示哪些 track 失败了

**GUI/ViewModels/SplitterViewModel.swift**
- `Completion` 新增 `coverEmbedded`、`metadataSucceededCount`、`metadataFailedCount`、`metadataFailures`
- 修复 `readCover()` 中 python3 路径（用和 MetadataEmbedder 一致的查找逻辑）

**GUI/Views/ContentView.swift (ResultView)**
- 新增元数据状态行：✅/⚠️/❌ + 具体文字说明
- 新增封面状态行
- 部分失败时在结果页底部展开失败详情（最多 5 条，超出提示还有更多）
- 结果页关闭静默成功 — 任何失败都有视觉提示

### 验收
- 元数据写入全部成功 → 显示绿色 ✅ 所有 N 个曲目元数据写入成功
- 元数据写入部分成功 → 显示橙色 ⚠️ + 失败 track 列表
- 元数据写入全部失败 → 显示红色 ❌ + 错误信息，整个处理标记为失败
- 封面获取失败 → 显示橙色 ⚠️ 封面未获取（不阻断）
- 结果页无需打开其他工具即可判断元数据完整性