### PR TITLE
fix: parse CUE FILE field and validate against actual FLAC path

### DIFF
--- a/Library/CueParser.swift
+++ b/Library/CueParser.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// Represents the FILE field in a CUE sheet.
+public struct CueFile: Sendable {
+    /// Raw path string as declared in CUE FILE "..." WAVE
+    public let path: String
+    /// Resolved URL relative to the CUE file's directory
+    public let resolvedURL: URL
+
+    public init(path: String, resolvedURL: URL) {
+        self.path = path
+        self.resolvedURL = resolvedURL
+    }
+}
+
 /// Represents a single track parsed from a CUE sheet.
 public struct CueTrack: Sendable {
     public let index: Int
@@ -46,7 +59,7 @@ private func decodeCueData(_ data: Data) -> String {
 }
 
 /// Parse a CUE file, trying multiple encodings for Chinese filename compatibility.
-public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: String?, performer: String?) {
+public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: String?, performer: String?, file: CueFile?) {
     let data = try Data(contentsOf: url)
     let text = decodeCueData(data)
 
@@ -56,6 +69,7 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
     var curIdx: Int = 0
     var curTitle: String = ""
     var curStart: Double = 0
+    var cueFile: CueFile?
 
     for raw in text.components(separatedBy: .newlines) {
         let line = raw.trimmingCharacters(in: .whitespaces)
@@ -69,6 +83,13 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
             } else {
                 albumTitle = cap
             }
+        }
+        // FILE "..." WAVE — parse audio file reference
+        else if let filePath = match(line: line, pattern: #"FILE "([^"]+)""#) {
+            let fileName = filePath.trimmingCharacters(in: .whitespaces)
+            let cueDir = url.deletingLastPathComponent()
+            let resolvedURL = cueDir.appendingPathComponent(fileName)
+            cueFile = CueFile(path: filePath, resolvedURL: resolvedURL)
         }
         // TRACK nn AUDIO
         else if let numStr = match(line: line, pattern: #"TRACK (\d+) AUDIO"#) {
@@ -89,7 +110,7 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
         tracks.append(CueTrack(index: curIdx, title: curTitle, startSeconds: curStart))
     }
 
-    return (tracks, albumTitle, performer)
+    return (tracks, albumTitle, performer, cueFile)
 }
 
 /// Find the .cue file corresponding to a FLAC URL.

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -9,6 +9,7 @@ public actor TrackSplitterEngine {
         case outputDirCreationFailed
         case splittingFailed(String)
         case metadataFailed(String)
+        case cueFileMismatch(cueDeclaredFile: String, actualFlacFile: String)
 
         public var errorDescription: String? {
             switch self {
@@ -17,6 +18,8 @@ public actor TrackSplitterEngine {
             case .outputDirCreationFailed: return "Failed to create output directory"
             case .splittingFailed(let msg): return "Splitting failed: \(msg)"
             case .metadataFailed(let msg): return "Metadata embedding failed: \(msg)"
+            case .cueFileMismatch(let cueDeclaredFile, let actualFlacFile):
+                return "CUE FILE field mismatch: CUE declares \"\(cueDeclaredFile)\" but input is \"\(actualFlacFile)\". Please ensure the FILE field in the CUE matches the actual audio file."
             }
         }
     }
@@ -62,8 +65,17 @@ public actor TrackSplitterEngine {
         log("📋 CUE found: \(cueURL.lastPathComponent)")
 
         // 2. Parse CUE (handles Chinese encodings via Big5/CP950 detection)
-        let (tracks, albumTitle, performer) = try parseCue(at: cueURL)
+        let (tracks, albumTitle, performer, cueFile) = try parseCue(at: cueURL)
         log("🎵 Tracks: \(tracks.count) | Album: \(albumTitle ?? "—") | Artist: \(performer ?? "—")")
+
+        // 2b. Validate FILE field if present
+        if let cf = cueFile {
+            let cueDeclaredName = cf.resolvedURL.lastPathComponent
+            if cueDeclaredName != flacURL.lastPathComponent {
+                log("⚠️  CUE FILE mismatch — CUE: \"\(cf.path)\", actual: \"\(flacURL.lastPathComponent)\"")
+                throw EngineError.cueFileMismatch(cueDeclaredFile: cf.path, actualFlacFile: flacURL.lastPathComponent)
+            }
+        }
 
         guard !tracks.isEmpty else { throw EngineError.emptyTracks }
 


### PR DESCRIPTION
## Summary

Fixes issue #5 — CUE FILE 字段未解析，路径不匹配时报错信息不明确。

## Changes

- **CueParser.swift**: 新增 CueFile struct；parseCue() 新增 FILE "..." WAVE 解析
- **TrackSplitterEngine.swift**: EngineError.cueFileMismatch 新增；process() 拆分前校验 FILE 字段

## 验收标准

1. CUE FILE 字段被正确解析（支持相对路径和绝对路径）
2. FILE 路径与实际 FLAC 不匹配时报错明确
3. 报告错误时同时显示 CUE 中的 FILE 值和实际 FLAC 路径

Closes #5