### PR TITLE
fix: parse CUE REM DATE/GENRE/COMMENT fields and embed as metadata

### DIFF
--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -106,15 +106,15 @@ else:
         }
 
         do {
-            let parsed = try parseCue(at: cueURL)
-            log("CUE parsed: \(parsed.tracks.count) tracks")
-            let previewTracks = fillPreviewEndTimes(for: parsed.tracks)
+            let (tracks, albumTitle, performer, _, _) = try parseCue(at: cueURL)
+            log("CUE parsed: \(tracks.count) tracks")
+            let previewTracks = fillPreviewEndTimes(for: tracks)
             let loaded = LoadedFiles(
                 flacURL: flacURL,
                 cueURL: cueURL,
                 tracks: previewTracks,
-                albumTitle: parsed.albumTitle,
-                performer: parsed.performer
+                albumTitle: albumTitle,
+                performer: performer
             )
             phase = .loaded(loaded)
             logs = []

--- a/Library/CueParser.swift
+++ b/Library/CueParser.swift
@@ -28,6 +28,24 @@ public struct CueTrack: Sendable {
     }
 }
 
+/// Represents REM fields parsed from a CUE sheet (album-level metadata).
+public struct CueRem: Sendable {
+    public var date: String?     // REM DATE "..."
+    public var genre: String?    // REM GENRE "..."
+    public var comment: String?  // REM COMMENT "..."
+    public var composer: String?  // REM COMPOSER "..."
+    public var discNumber: String? // REM DISCNUMBER "..."
+
+    public init(date: String? = nil, genre: String? = nil, comment: String? = nil,
+                composer: String? = nil, discNumber: String? = nil) {
+        self.date = date
+        self.genre = genre
+        self.comment = comment
+        self.composer = composer
+        self.discNumber = discNumber
+    }
+}
+
 /// Attempt to decode CUE data, trying UTF-8 → Big5 via iconv → ISO Latin 1 fallback.
 private func decodeCueData(_ data: Data) -> String {
     // Try UTF-8 first
@@ -59,7 +77,7 @@ private func decodeCueData(_ data: Data) -> String {
 }
 
 /// Parse a CUE file, trying multiple encodings for Chinese filename compatibility.
-public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: String?, performer: String?, file: CueFile?) {
+public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: String?, performer: String?, file: CueFile?, rem: CueRem) {
     let data = try Data(contentsOf: url)
     let text = decodeCueData(data)
 
@@ -70,6 +88,7 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
     var curTitle: String = ""
     var curStart: Double = 0
     var cueFile: CueFile?
+    var rem = CueRem()
 
     for raw in text.components(separatedBy: .newlines) {
         let line = raw.trimmingCharacters(in: .whitespaces)
@@ -104,13 +123,33 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
         else if let ts = parseTimestamp(line: line, pattern: "INDEX 01 (\\d+):(\\d+):(\\d+)$") {
             curStart = ts
         }
+        // REM DATE "..."
+        else if let cap = match(line: line, pattern: #"REM DATE "?(.+)"?$"#) {
+            rem.date = cap.trimmingCharacters(in: CharacterSet(charactersIn: "\" "))
+        }
+        // REM GENRE "..."
+        else if let cap = match(line: line, pattern: #"REM GENRE "?(.+)"?$"#) {
+            rem.genre = cap.trimmingCharacters(in: CharacterSet(charactersIn: "\" "))
+        }
+        // REM COMMENT "..."
+        else if let cap = match(line: line, pattern: #"REM COMMENT "?(.+)"?$"#) {
+            rem.comment = cap.trimmingCharacters(in: CharacterSet(charactersIn: "\" "))
+        }
+        // REM COMPOSER "..."
+        else if let cap = match(line: line, pattern: #"REM COMPOSER "?(.+)"?$"#) {
+            rem.composer = cap.trimmingCharacters(in: CharacterSet(charactersIn: "\" "))
+        }
+        // REM DISCNUMBER "..."
+        else if let cap = match(line: line, pattern: #"REM DISCNUMBER "?(.+)"?$"#) {
+            rem.discNumber = cap.trimmingCharacters(in: CharacterSet(charactersIn: "\" "))
+        }
     }
 
     if curIdx > 0 {
         tracks.append(CueTrack(index: curIdx, title: curTitle, startSeconds: curStart))
     }
 
-    return (tracks, albumTitle, performer, cueFile)
+    return (tracks, albumTitle, performer, cueFile, rem)
 }
 
 /// Find the .cue file corresponding to a FLAC URL.

--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -77,6 +77,9 @@ public actor MetadataEmbedder {
         album: String,
         year: String,
         genre: String,
+        comment: String?,
+        composer: String?,
+        discNumber: String?,
         totalTracks: Int,
         coverData: Data?
     ) async throws -> EmbedResult {
@@ -84,11 +87,15 @@ public actor MetadataEmbedder {
             let path: String; let title: String; let artist: String
             let album: String; let year: String; let genre: String
             let tracknum: String; let total: String
+            let comment: String?
+            let composer: String?
+            let discNumber: String?
         }
 
         let items = files.map { f in
             Item(path: f.url.path, title: f.title, artist: artist, album: album,
-                 year: year, genre: genre, tracknum: String(f.trackNumber), total: String(totalTracks))
+                 year: year, genre: genre, tracknum: String(f.trackNumber), total: String(totalTracks),
+                 comment: comment, composer: composer, discNumber: discNumber)
         }
 
         let coverB64: String? = coverData.map { Data($0).base64EncodedString() }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -65,8 +65,9 @@ public actor TrackSplitterEngine {
         log("📋 CUE found: \(cueURL.lastPathComponent)")
 
         // 2. Parse CUE (handles Chinese encodings via Big5/CP950 detection)
-        let (tracks, albumTitle, performer, cueFile) = try parseCue(at: cueURL)
+        let (tracks, albumTitle, performer, cueFile, cueRem) = try parseCue(at: cueURL)
         log("🎵 Tracks: \(tracks.count) | Album: \(albumTitle ?? "—") | Artist: \(performer ?? "—")")
+        log("📋 REM: date=\(cueRem.date ?? "—") genre=\(cueRem.genre ?? "—") comment=\(cueRem.comment ?? "—") composer=\(cueRem.composer ?? "—") discNumber=\(cueRem.discNumber ?? "—")")
 
         // 2b. Validate FILE field if present
         if let cf = cueFile {
@@ -123,8 +124,11 @@ public actor TrackSplitterEngine {
                 files: zip(splitTracks, tracks).map { (url: $0.0, title: $0.1.title, trackNumber: $0.1.index) },
                 artist: performer ?? "Unknown Artist",
                 album: albumTitle ?? albumDirName,
-                year: "1992",
-                genre: "流行",
+                year: cueRem.date ?? "",
+                genre: cueRem.genre ?? "",
+                comment: cueRem.comment,
+                composer: cueRem.composer,
+                discNumber: cueRem.discNumber,
                 totalTracks: tracks.count,
                 coverData: coverData
             )

--- a/Resources/embed_metadata.py
+++ b/Resources/embed_metadata.py
@@ -45,6 +45,13 @@ def main():
             audio["TOTALTRACKS"] = item.get("total", "")
             audio["ALBUMARTIST"] = item.get("artist", "")
 
+            if item.get("comment"):
+                audio["COMMENT"] = item["comment"]
+            if item.get("composer"):
+                audio["COMPOSER"] = item["composer"]
+            if item.get("discNumber"):
+                audio["DISCNUMBER"] = item["discNumber"]
+
             if cover_bytes:
                 audio.clear_pictures()
                 pic = Picture()

--- a/ViewModels/SplitterViewModel.swift
+++ b/ViewModels/SplitterViewModel.swift
@@ -25,14 +25,14 @@ final class SplitterViewModel: ObservableObject {
 
         do {
             // 解析 CUE 并构造用于预览的曲目时间区间。
-            let parsed = try parseCue(at: cueURL)
-            let previewTracks = fillPreviewEndTimes(for: parsed.tracks)
+            let (tracks, albumTitle, performer, _, _) = try parseCue(at: cueURL)
+            let previewTracks = fillPreviewEndTimes(for: tracks)
             let loaded = AppState.LoadedFiles(
                 flacURL: flacURL,
                 cueURL: cueURL,
                 tracks: previewTracks,
-                albumTitle: parsed.albumTitle,
-                performer: parsed.performer
+                albumTitle: albumTitle,
+                performer: performer
             )
             appState.phase = .loaded(loaded)
             appState.logs = []


### PR DESCRIPTION
## 修复 Issue #2

**问题**: 元数据字段 year/genre 硬编码为 '1992'/'流行'，CUE 中的 REM DATE/GENRE/COMMENT 等字段未被解析和使用。

**改动**:

1. **CueParser.swift**: 新增 `CueRem` struct，解析 REM DATE/GENRE/COMMENT/COMPOSER/DISCNUMBER 字段
2. **TrackSplitterEngine.swift**: 使用解析出的 year/genre 替代硬编码值，传递 comment/composer/discNumber
3. **MetadataEmbedder.swift**: `embedBatch()` 新增 comment/composer/discNumber 参数
4. **embed_metadata.py**: 写入 COMMENT、COMPOSER、DISCNUMBER FLAC tag
5. **两个 SplitterViewModel**: 适配 `parseCue()` 新的 5-tuple 返回值

**验收标准**:
- [x] CUE 中的 REM DATE / REM GENRE 能被正确解析并写入 FLAC
- [x] 支持 COMMENT、COMPOSER、DISCNUMBER 字段写入
