### PR TITLE
feat: support multiple input audio formats

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -21,8 +21,8 @@ final class AppState: ObservableObject {
 
     /// 已加载文件上下文。
     struct LoadedFiles {
-        /// 用户选择的 FLAC 文件。
-        let flacURL: URL
+        /// 用户选择的音频文件。
+        let audioURL: URL
         /// 自动匹配到的 CUE 文件。
         let cueURL: URL
         /// 解析出的曲目列表。

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -16,29 +16,31 @@ struct TrackSplitterCLI {
             return
         }
 
-        // CLI mode: positional FLAC path
-        let flacPath = args.first { !$0.hasPrefix("-") }
-        guard let flacPath else {
-            print("Error: No FLAC file specified. Pass a .flac file path.")
+        // CLI mode: positional audio file path
+        let audioPath = args.first { !$0.hasPrefix("-") }
+        guard let audioPath else {
+            print("Error: No audio file specified. Pass a supported audio file path.")
             print("Run 'tracksplitter --help' for usage.")
             exit(1)
         }
 
-        runCLI(flacPath: flacPath)
+        runCLI(audioPath: audioPath)
     }
 
     // MARK: - CLI mode
 
-    private static func runCLI(flacPath: String) {
-        let flacURL = URL(fileURLWithPath: flacPath)
+    private static func runCLI(audioPath: String) {
+        let audioURL = URL(fileURLWithPath: audioPath)
 
-        guard FileManager.default.fileExists(atPath: flacURL.path) else {
-            print("Error: File not found: \(flacPath)")
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            print("Error: File not found: \(audioPath)")
             exit(1)
         }
 
-        guard flacURL.pathExtension.lowercased() == "flac" else {
-            print("Error: File is not a FLAC file: \(flacURL.lastPathComponent)")
+        let supported: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
+        guard supported.contains(audioURL.pathExtension.lowercased()) else {
+            print("Error: Unsupported file format: \(audioURL.lastPathComponent)")
+            print("Supported: FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus")
             exit(1)
         }
 
@@ -55,7 +57,7 @@ struct TrackSplitterCLI {
 
         Task {
             do {
-                let result = try await engine.process(flacURL: flacURL)
+                let result = try await engine.process(inputURL: audioURL)
                 print("\n✅ Done! \(result.trackFiles.count) tracks saved to:")
                 print("   \(result.outputDirectory.path)")
             } catch {
@@ -75,10 +77,12 @@ struct TrackSplitterCLI {
     // MARK: - Help text
 
     static let helpText = """
-    TrackSplitter — Split FLAC+CUE albums into individual tracks with metadata.
+    TrackSplitter — Split audio+CUE albums into individual tracks with metadata.
+
+    Supported formats: FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus
 
     Usage:
-      tracksplitter <file.flac>        Process a FLAC file from the command line
+      tracksplitter <file>        Process an audio file from the command line
 
     Options:
       --help, -h  Show this help
@@ -86,6 +90,7 @@ struct TrackSplitterCLI {
 
     Examples:
       tracksplitter "/Users/music/陈升-别让我哭.flac"
+      tracksplitter "/Users/music/album.mp3"
 
     Requirements:
       • ffmpeg    (brew install ffmpeg)

--- a/GUI/App/AppState.swift
+++ b/GUI/App/AppState.swift
@@ -20,8 +20,8 @@ final class AppState: ObservableObject {
 
     /// 已加载文件上下文。
     struct LoadedFiles {
-        /// 用户选择的 FLAC 文件。
-        let flacURL: URL
+        /// 用户选择的音频文件。
+        let audioURL: URL
         /// 自动匹配到的 CUE 文件。
         let cueURL: URL
         /// 解析出的曲目列表。

--- a/GUI/App/TrackSplitterApp.swift
+++ b/GUI/App/TrackSplitterApp.swift
@@ -89,9 +89,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.init(filenameExtension: "flac") ?? .audio]
-        panel.title = "选择 FLAC 文件"
-        panel.message = "选择要拆分的 FLAC 整轨文件"
+        panel.allowedContentTypes = [
+            .init(filenameExtension: "flac") ?? .audio,
+            .init(filenameExtension: "mp3") ?? .audio,
+            .init(filenameExtension: "wav") ?? .audio,
+            .init(filenameExtension: "aiff") ?? .audio,
+            .init(filenameExtension: "m4a") ?? .audio,
+            .init(filenameExtension: "aac") ?? .audio,
+            .init(filenameExtension: "ogg") ?? .audio,
+            .init(filenameExtension: "opus") ?? .audio,
+        ]
+        panel.title = "选择音频文件"
+        panel.message = "选择要拆分的整轨音频文件"
 
         if let window = self.window {
             panel.beginSheetModal(for: window) { response in

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -1,6 +1,29 @@
 import Foundation
 import Combine
 
+/// Output format selection for the split.
+public enum AudioSplitterOutputFormat: String, CaseIterable, Identifiable {
+    case keepOriginal = ""
+    case flac = "flac"
+    case wav = "wav"
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .keepOriginal: return "保持原格式"
+        case .flac: return "FLAC"
+        case .wav: return "WAV"
+        }
+    }
+
+    /// Convert to AudioSplitter.AudioFormat for engine call, or nil for passthrough.
+    public var audioFormat: AudioSplitter.AudioFormat? {
+        guard self != .keepOriginal else { return nil }
+        return AudioSplitter.AudioFormat(rawValue: self.rawValue)
+    }
+}
+
 /// 负责协调界面与核心引擎的视图模型。
 /// 直接持有所有 @Published 状态，不通过中间 AppState，避免跨对象观察链失效。
 @MainActor
@@ -88,6 +111,8 @@ else:
     @Published var progress: Double = 0
     @Published var isShowingErrorAlert: Bool = false
     @Published var errorMessage: String = ""
+    /// Selected output format for the split. nil = same as input.
+    @Published var selectedOutputFormat: AudioSplitterOutputFormat = .keepOriginal
 
     // MARK: - Actions
     func load(audioURL: URL) {
@@ -146,7 +171,8 @@ else:
         Task {
             do {
                 let engine = TrackSplitterEngine(logHandler: handler)
-                let result = try await engine.process(inputURL: loaded.audioURL)
+                let result = try await engine.process(inputURL: loaded.audioURL,
+                                                      outputFormat: selectedOutputFormat.audioFormat)
                 let (coverData, _) = Completion.readCover(from: result.trackFiles)
                 let completion = Completion(
                     outputDirectory: result.outputDirectory,

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -26,14 +26,14 @@ final class SplitterViewModel: ObservableObject {
     }
 
     struct LoadedFiles: Equatable {
-        let flacURL: URL
+        let audioURL: URL
         let cueURL: URL
         let tracks: [CueTrack]
         let albumTitle: String?
         let performer: String?
 
         static func == (lhs: LoadedFiles, rhs: LoadedFiles) -> Bool {
-            lhs.flacURL == rhs.flacURL && lhs.cueURL == rhs.cueURL
+            lhs.audioURL == rhs.audioURL && lhs.cueURL == rhs.cueURL
         }
     }
 
@@ -90,18 +90,19 @@ else:
     @Published var errorMessage: String = ""
 
     // MARK: - Actions
-    func load(flacURL: URL) {
-        log("load() called: \(flacURL.path)")
+    func load(audioURL: URL) {
+        log("load() called: \(audioURL.path)")
 
-        guard flacURL.pathExtension.lowercased() == "flac" else {
-            log("FAIL: not .flac")
-            setError("仅支持 .flac 文件")
+        let supported: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
+        guard supported.contains(audioURL.pathExtension.lowercased()) else {
+            log("FAIL: unsupported format")
+            setError("不支持的文件格式。支持：FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus")
             return
         }
 
-        guard let cueURL = findCue(for: flacURL) else {
+        guard let cueURL = findCue(for: audioURL) else {
             log("FAIL: CUE not found")
-            setError("未找到同名 CUE 文件：\(flacURL.deletingPathExtension().lastPathComponent).cue")
+            setError("未找到匹配的 CUE 文件（请确认 CUE 中 FILE 字段与音频文件名一致）")
             return
         }
 
@@ -110,7 +111,7 @@ else:
             log("CUE parsed: \(tracks.count) tracks")
             let previewTracks = fillPreviewEndTimes(for: tracks)
             let loaded = LoadedFiles(
-                flacURL: flacURL,
+                audioURL: audioURL,
                 cueURL: cueURL,
                 tracks: previewTracks,
                 albumTitle: albumTitle,
@@ -145,7 +146,7 @@ else:
         Task {
             do {
                 let engine = TrackSplitterEngine(logHandler: handler)
-                let result = try await engine.process(flacURL: loaded.flacURL)
+                let result = try await engine.process(inputURL: loaded.audioURL)
                 let (coverData, _) = Completion.readCover(from: result.trackFiles)
                 let completion = Completion(
                     outputDirectory: result.outputDirectory,

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -6,19 +6,22 @@ import UniformTypeIdentifiers
 /// 主窗口视图：直接观察 SplitterViewModel，无需中间 AppState。
 struct ContentView: View {
     @StateObject private var viewModel = SplitterViewModel()
+    @State private var selectedOutputFormat = AudioSplitterOutputFormat.keepOriginal
 
     var body: some View {
         Group {
             switch viewModel.phase {
             case .idle:
                 IdleView(onFileSelected: { url in
+                    selectedOutputFormat = .keepOriginal
                     viewModel.load(audioURL: url)
                 })
 
             case .loaded(let loaded):
                 LoadedView(
                     loaded: loaded,
-                    onStart: { viewModel.startProcessing() }
+                    onStart: { viewModel.startProcessing() },
+                    selectedOutputFormat: $selectedOutputFormat
                 )
 
             case .processing:
@@ -36,7 +39,10 @@ struct ContentView: View {
                             inFileViewerRootedAtPath: completion.outputDirectory.deletingLastPathComponent().path
                         )
                     },
-                    onProcessAnother: { viewModel.processAnother() }
+                    onProcessAnother: {
+                        selectedOutputFormat = .keepOriginal
+                        viewModel.processAnother()
+                    }
                 )
 
             case .error(let message):
@@ -110,7 +116,7 @@ final class IdleViewController: NSViewController {
         container.addSubview(dropZone)
 
         // 选择按钮。
-        let selectButton = NSButton(title: "从磁盘选择 FLAC 文件", target: self, action: #selector(selectButtonClicked))
+        let selectButton = NSButton(title: "从磁盘选择音频文件", target: self, action: #selector(selectButtonClicked))
         selectButton.translatesAutoresizingMaskIntoConstraints = false
         selectButton.bezelStyle = .rounded
         selectButton.controlSize = .large
@@ -151,9 +157,18 @@ final class IdleViewController: NSViewController {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [.init(filenameExtension: "flac") ?? .audio]
-        panel.title = "选择 FLAC 文件"
-        panel.message = "选择要拆分的 FLAC 整轨文件"
+        panel.allowedContentTypes = [
+            .init(filenameExtension: "flac") ?? .audio,
+            .init(filenameExtension: "mp3") ?? .audio,
+            .init(filenameExtension: "wav") ?? .audio,
+            .init(filenameExtension: "aiff") ?? .audio,
+            .init(filenameExtension: "m4a") ?? .audio,
+            .init(filenameExtension: "aac") ?? .audio,
+            .init(filenameExtension: "ogg") ?? .audio,
+            .init(filenameExtension: "opus") ?? .audio,
+        ]
+        panel.title = "选择音频文件"
+        panel.message = "选择要拆分的整轨音频文件"
         if panel.runModal() == .OK, let url = panel.url {
             onFileSelected?(url)
         }
@@ -202,14 +217,18 @@ final class DropZoneVisualView: NSView {
         return true
     }
 
+    private static let _supportedExtensions: Set<String> = [
+        "flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"
+    ]
+
     private func hasFlacFile(_ info: NSDraggingInfo) -> Bool {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else { return false }
-        return urls.contains { $0.pathExtension.lowercased() == "flac" }
+        return urls.contains { Self._supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
     private func extractFlacUrl(_ info: NSDraggingInfo) -> URL? {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else { return nil }
-        return urls.first { $0.pathExtension.lowercased() == "flac" }
+        return urls.first { Self._supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -233,7 +252,7 @@ final class DropZoneVisualView: NSView {
             image.draw(in: rect, from: .zero, operation: .sourceOver, fraction: isDragOver ? 1.0 : 0.6)
         }
 
-        let text = "拖放 FLAC 文件到这里"
+        let text = "拖放音频文件到这里"
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
         let attrs: [NSAttributedString.Key: Any] = [
@@ -265,6 +284,7 @@ struct IdleView: NSViewControllerRepresentable {
 struct LoadedView: View {
     let loaded: SplitterViewModel.LoadedFiles
     let onStart: () -> Void
+    @Binding var selectedOutputFormat: AudioSplitterOutputFormat
 
     var body: some View {
         VStack(spacing: 0) {
@@ -311,6 +331,21 @@ struct LoadedView: View {
                     .lineLimit(1)
 
                 Spacer()
+
+                // Output format selector
+                HStack(spacing: 8) {
+                    Text("输出格式：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Picker("", selection: $selectedOutputFormat) {
+                        ForEach(AudioSplitterOutputFormat.allCases) { fmt in
+                            Text(fmt.displayName).tag(fmt)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 200)
+                }
 
                 Button(action: onStart) {
                     HStack(spacing: 6) {

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
             switch viewModel.phase {
             case .idle:
                 IdleView(onFileSelected: { url in
-                    viewModel.load(flacURL: url)
+                    viewModel.load(audioURL: url)
                 })
 
             case .loaded(let loaded):
@@ -48,7 +48,7 @@ struct ContentView: View {
         .frame(minWidth: 640, minHeight: 480)
         .onReceive(NotificationCenter.default.publisher(for: .didSelectFlacFile)) { notification in
             if let url = notification.object as? URL {
-                viewModel.load(flacURL: url)
+                viewModel.load(audioURL: url)
             }
         }
     }
@@ -279,7 +279,7 @@ struct LoadedView: View {
                     Text(loaded.performer ?? "未知艺术家")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                    Text(loaded.flacURL.lastPathComponent)
+                    Text(loaded.audioURL.lastPathComponent)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -6,14 +6,13 @@ import UniformTypeIdentifiers
 /// 主窗口视图：直接观察 SplitterViewModel，无需中间 AppState。
 struct ContentView: View {
     @StateObject private var viewModel = SplitterViewModel()
-    @State private var selectedOutputFormat = AudioSplitterOutputFormat.keepOriginal
 
     var body: some View {
         Group {
             switch viewModel.phase {
             case .idle:
                 IdleView(onFileSelected: { url in
-                    selectedOutputFormat = .keepOriginal
+                    viewModel.selectedOutputFormat = .keepOriginal
                     viewModel.load(audioURL: url)
                 })
 
@@ -21,7 +20,7 @@ struct ContentView: View {
                 LoadedView(
                     loaded: loaded,
                     onStart: { viewModel.startProcessing() },
-                    selectedOutputFormat: $selectedOutputFormat
+                    selectedOutputFormat: $viewModel.selectedOutputFormat
                 )
 
             case .processing:
@@ -40,7 +39,7 @@ struct ContentView: View {
                         )
                     },
                     onProcessAnother: {
-                        selectedOutputFormat = .keepOriginal
+                        viewModel.selectedOutputFormat = .keepOriginal
                         viewModel.processAnother()
                     }
                 )
@@ -99,7 +98,7 @@ final class IdleViewController: NSViewController {
         container.addSubview(titleLabel)
 
         // 副标题。
-        let subtitleLabel = NSTextField(labelWithString: "将 FLAC 整轨专辑拆分为独立曲目")
+        let subtitleLabel = NSTextField(labelWithString: "将整轨音频拆分为独立曲目（FLAC/MP3/WAV/AIFF/M4A/AAC/OGG/Opus）")
         subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
         subtitleLabel.font = .systemFont(ofSize: 14)
         subtitleLabel.textColor = .secondaryLabelColor

--- a/GUI/Views/DropZoneView.swift
+++ b/GUI/Views/DropZoneView.swift
@@ -104,7 +104,9 @@ class DropZoneNSView: NSView {
     // MARK: - 拖放支持
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard hasValidAudioFile(sender) else { return [] }
+        guard hasValidAudioFile(sender) else {
+            return []
+        }
         isDragHighlighted = true
         return .copy
     }
@@ -135,6 +137,7 @@ class DropZoneNSView: NSView {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return false
         }
+        let exts = urls.map { $0.pathExtension.lowercased() }
         return urls.contains { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 

--- a/GUI/Views/DropZoneView.swift
+++ b/GUI/Views/DropZoneView.swift
@@ -26,8 +26,22 @@ class DropZoneNSView: NSView {
         didSet { needsDisplay = true }
     }
 
-    /// FLAC 类型。
-    private let flacType = UTType(filenameExtension: "flac") ?? .data
+    /// 支持的音频格式列表。
+    private static let supportedExtensions: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
+
+    /// 支持的 UTType 列表。
+    private static var supportedTypes: [UTType] {
+        [
+            UTType(filenameExtension: "flac") ?? .data,
+            UTType(filenameExtension: "mp3") ?? .data,
+            UTType(filenameExtension: "wav") ?? .data,
+            UTType(filenameExtension: "aiff") ?? .data,
+            UTType(filenameExtension: "m4a") ?? .data,
+            UTType(filenameExtension: "aac") ?? .data,
+            UTType(filenameExtension: "ogg") ?? .data,
+            UTType(filenameExtension: "opus") ?? .data,
+        ]
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -44,7 +58,7 @@ class DropZoneNSView: NSView {
         registerForDraggedTypes([.fileURL])
 
         // 添加"选择文件"按钮。
-        let button = NSButton(title: "选择 FLAC 文件", target: self, action: #selector(openFilePicker))
+        let button = NSButton(title: "选择音频文件", target: self, action: #selector(openFilePicker))
         button.bezelStyle = .rounded
         button.controlSize = .large
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -65,9 +79,9 @@ class DropZoneNSView: NSView {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [flacType]
-        panel.title = "选择 FLAC 文件"
-        panel.message = "请选择要拆分的 FLAC 文件"
+        panel.allowedContentTypes = Self.supportedTypes
+        panel.title = "选择音频文件"
+        panel.message = "请选择要拆分的音频文件（FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus）"
 
         // 设置为 sheet 模式，避免阻塞主事件循环。
         if let window = self.window {
@@ -90,13 +104,13 @@ class DropZoneNSView: NSView {
     // MARK: - 拖放支持
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard hasValidFlacFile(sender) else { return [] }
+        guard hasValidAudioFile(sender) else { return [] }
         isDragHighlighted = true
         return .copy
     }
 
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        hasValidFlacFile(sender) ? .copy : []
+        hasValidAudioFile(sender) ? .copy : []
     }
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
@@ -104,32 +118,32 @@ class DropZoneNSView: NSView {
     }
 
     override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        hasValidFlacFile(sender)
+        hasValidAudioFile(sender)
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         isDragHighlighted = false
-        guard let fileURL = extractFlacFile(sender) else { return false }
+        guard let fileURL = extractAudioFile(sender) else { return false }
         fputs("[TrackSplitter] Dropped file: \(fileURL.path)\n", stderr)
         fflush(stderr)
         onFileSelected?(fileURL)
         return true
     }
 
-    /// 检查拖放数据中是否包含有效的 FLAC 文件。
-    private func hasValidFlacFile(_ info: NSDraggingInfo) -> Bool {
+    /// 检查拖放数据中是否包含有效的音频文件。
+    private func hasValidAudioFile(_ info: NSDraggingInfo) -> Bool {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return false
         }
-        return urls.contains { $0.pathExtension.lowercased() == "flac" }
+        return urls.contains { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
-    /// 从拖放数据中提取 FLAC 文件 URL。
-    private func extractFlacFile(_ info: NSDraggingInfo) -> URL? {
+    /// 从拖放数据中提取音频文件 URL。
+    private func extractAudioFile(_ info: NSDraggingInfo) -> URL? {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return nil
         }
-        return urls.filter { $0.pathExtension.lowercased() == "flac" }.first
+        return urls.first { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
     // MARK: - 绘制
@@ -170,7 +184,7 @@ class DropZoneNSView: NSView {
             .paragraphStyle: paragraphStyle
         ]
         let textRect = NSRect(x: 0, y: bounds.midY - 40, width: bounds.width, height: 20)
-        "拖放 FLAC 文件到此处".draw(in: textRect, withAttributes: textAttrs)
+        "拖放音频文件到此处".draw(in: textRect, withAttributes: textAttrs)
     }
 }
 

--- a/GUI/Views/DropZoneView.swift.bak
+++ b/GUI/Views/DropZoneView.swift.bak
@@ -3,7 +3,7 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 // MARK: - DropZoneView (纯 AppKit 实现，兼容性与稳定性更高)
-/// 音频文件拖放与选择组件，支持 FLAC/MP3/WAV/AIFF/M4A/AAC/OGG/Opus。
+/// FLAC 文件拖放与选择组件。
 /// 使用 NSView 封装而不是纯 SwiftUI onDrop，以避免 NSHostingView 环境下的拖放事件丢失。
 struct DropZoneView: View {
     /// 文件选中回调。
@@ -27,11 +27,9 @@ class DropZoneNSView: NSView {
     }
 
     /// 支持的音频格式列表。
-    private static let supportedExtensions: Set<String> = [
-        "flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"
-    ]
+    private static let supportedExtensions: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
 
-    /// 支持的 UTType 列表（按优先级排序）。
+    /// 支持的 UTType 列表。
     private static var supportedTypes: [UTType] {
         [
             UTType(filenameExtension: "flac") ?? .data,
@@ -56,8 +54,10 @@ class DropZoneNSView: NSView {
     }
 
     private func setup() {
+        // 注册为接受文件拖放。
         registerForDraggedTypes([.fileURL])
 
+        // 添加"选择文件"按钮。
         let button = NSButton(title: "选择音频文件", target: self, action: #selector(openFilePicker))
         button.bezelStyle = .rounded
         button.controlSize = .large
@@ -70,6 +70,7 @@ class DropZoneNSView: NSView {
         ])
     }
 
+    /// 打开文件选择器。
     @objc private func openFilePicker() {
         fputs("[TrackSplitter] openFilePicker called\n", stderr)
         fflush(stderr)
@@ -82,6 +83,7 @@ class DropZoneNSView: NSView {
         panel.title = "选择音频文件"
         panel.message = "请选择要拆分的音频文件（FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus）"
 
+        // 设置为 sheet 模式，避免阻塞主事件循环。
         if let window = self.window {
             panel.beginSheetModal(for: window) { [weak self] response in
                 guard response == .OK, let url = panel.url else { return }
@@ -90,6 +92,7 @@ class DropZoneNSView: NSView {
                 self?.onFileSelected?(url)
             }
         } else {
+            // 没有 window 时用 modal 模式。
             if panel.runModal() == .OK, let url = panel.url {
                 fputs("[TrackSplitter] File selected (modal): \(url.path)\n", stderr)
                 fflush(stderr)
@@ -127,6 +130,7 @@ class DropZoneNSView: NSView {
         return true
     }
 
+    /// 检查拖放数据中是否包含有效的音频文件。
     private func hasValidAudioFile(_ info: NSDraggingInfo) -> Bool {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return false
@@ -134,6 +138,7 @@ class DropZoneNSView: NSView {
         return urls.contains { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
+    /// 从拖放数据中提取音频文件 URL。
     private func extractAudioFile(_ info: NSDraggingInfo) -> URL? {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return nil
@@ -149,10 +154,12 @@ class DropZoneNSView: NSView {
         let bgColor = NSColor.controlBackgroundColor
         let borderColor = isDragHighlighted ? NSColor.controlAccentColor : NSColor.separatorColor
 
+        // 背景。
         bgColor.setFill()
         let bgPath = NSBezierPath(roundedRect: bounds.insetBy(dx: 2, dy: 2), xRadius: 14, yRadius: 14)
         bgPath.fill()
 
+        // 虚线边框。
         borderColor.setStroke()
         let borderPath = NSBezierPath(roundedRect: bounds.insetBy(dx: 2, dy: 2), xRadius: 14, yRadius: 14)
         borderPath.lineWidth = 2
@@ -160,6 +167,7 @@ class DropZoneNSView: NSView {
         borderPath.setLineDash(dashPattern, count: 2, phase: 0)
         borderPath.stroke()
 
+        // 中心图标和文字。
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
 
@@ -181,6 +189,7 @@ class DropZoneNSView: NSView {
 }
 
 // MARK: - SwiftUI NSViewRepresentable 桥接
+/// 将 DropZoneNSView 桥接到 SwiftUI。
 struct DropZoneViewRepresentable: NSViewRepresentable {
     let onFileSelected: (URL) -> Void
 

--- a/GUI/project.yml
+++ b/GUI/project.yml
@@ -24,6 +24,9 @@ targets:
       - path: ../Library
         type: group
         name: TrackSplitterLib
+    resources:
+      - path: ../Resources/embed_metadata.py
+        buildPhase: resources
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tracksplitter.gui

--- a/GUI/project.yml
+++ b/GUI/project.yml
@@ -24,9 +24,11 @@ targets:
       - path: ../Library
         type: group
         name: TrackSplitterLib
-    resources:
-      - path: ../Resources/embed_metadata.py
-        buildPhase: resources
+    postBuildScripts:
+      - name: Copy embed_metadata.py
+        script: |
+          cp "${PROJECT_DIR}/../Resources/embed_metadata.py" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Resources/"
+        basedOnDependencyAnalysis: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tracksplitter.gui

--- a/Library/AlbumArtFetcher.swift
+++ b/Library/AlbumArtFetcher.swift
@@ -18,9 +18,18 @@ public actor AlbumArtFetcher {
     }
 
     /// Fetch album art as JPEG Data. Tries multiple sources in order.
+    /// Local files (same directory as input) are checked first for offline reliability.
     /// Returns on first successful fetch; throws `notFound` only if all sources fail.
-    public func fetch(artist: String?, album: String) async throws -> Data {
-        // Try each source; stop at first success
+    public func fetch(artist: String?, album: String, inputFile: URL? = nil) async throws -> Data {
+        // 1. Local file fallback (same directory as audio input) — pick the largest image
+        if let input = inputFile {
+            let dir = input.deletingLastPathComponent()
+            if let data = largestImage(in: dir) {
+                return data
+            }
+        }
+
+        // 2. Online sources
         let sources: [() async throws -> Data] = [
             { try await self.fetchFromLeftFM(album: album) },
             { try await self.fetchFromMusicBrainz(artist: artist, album: album) },
@@ -40,6 +49,38 @@ public actor AlbumArtFetcher {
         }
 
         throw lastError
+    }
+
+    private func isImageData(_ data: Data) -> Bool {
+        guard data.count >= 4 else { return false }
+        let header = data.prefix(4)
+        return header.starts(with: [0xFF, 0xD8, 0xFF]) ||
+               header.starts(with: [0x89, 0x50, 0x4E, 0x47])
+    }
+
+    /// Pick the largest image file from a directory — good heuristic for album art.
+    private func largestImage(in dir: URL) -> Data? {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: dir.path) else { return nil }
+
+        let imageExts = Set(["jpg", "jpeg", "png"])
+        var candidates: [(name: String, size: Int)] = []
+
+        for entry in entries {
+            let ext = (entry as NSString).pathExtension.lowercased()
+            guard imageExts.contains(ext) else { continue }
+            let fullURL = dir.appendingPathComponent(entry)
+            if let attrs = try? fm.attributesOfItem(atPath: fullURL.path),
+               let size = attrs[.size] as? Int, size > 5000 {
+                candidates.append((entry, size))
+            }
+        }
+
+        // Pick the largest (cover art is usually the biggest image)
+        if let best = candidates.max(by: { $0.size < $1.size }) {
+            return try? Data(contentsOf: dir.appendingPathComponent(best.name))
+        }
+        return nil
     }
 
     // MARK: - Source 1: leftfm.com (Chinese music album covers)

--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -1,19 +1,46 @@
 import Foundation
 
-/// Runs ffmpeg to split a FLAC file into individual tracks.
-public actor FLACSplitter {
+/// Runs ffmpeg to split an audio file into individual tracks.
+/// Supports any format ffmpeg can read: FLAC, MP3, WAV, AIFF, ALAC, AAC, OGG, etc.
+public actor AudioSplitter {
 
     public enum SplitError: Error, LocalizedError {
         case ffprobeFailed(String)
         case ffmpegFailed(String, Int32)
         case noDuration
+        case unsupportedFormat(String)
 
         public var errorDescription: String? {
             switch self {
             case .ffprobeFailed(let msg): return "ffprobe error: \(msg)"
             case .ffmpegFailed(let msg, let code): return "ffmpeg exited with \(code): \(msg)"
             case .noDuration: return "Could not determine total file duration"
+            case .unsupportedFormat(let ext): return "Unsupported file format: \(ext)"
             }
+        }
+    }
+
+    /// Supported input audio formats.
+    public enum AudioFormat: String, CaseIterable, Sendable {
+        case flac = "flac"
+        case mp3  = "mp3"
+        case wav  = "wav"
+        case aiff = "aiff"
+        case alac = "alac"
+        case m4a  = "m4a"
+        case aac  = "aac"
+        case ogg  = "ogg"
+        case opus = "opus"
+
+        public var isSupported: Bool {
+            // All formats listed here are natively supported by ffmpeg.
+            true
+        }
+
+        /// Infer format from file extension.
+        public static func fromExtension(_ ext: String) -> AudioFormat? {
+            let lower = ext.lowercased()
+            return Self.allCases.first { $0.rawValue == lower }
         }
     }
 
@@ -33,21 +60,17 @@ public actor FLACSplitter {
     }
 
     private static func findBinary(_ name: String) -> String? {
-        // Hardcode homebrew paths first, then fall back to PATH lookup.
-        // GUI apps started via Finder/NSOpenPanel don't inherit a full PATH.
         let homebrewPaths = [
             "/opt/homebrew/bin/\(name)",
             "/opt/homebrew/bin/\(name)3",
             "/usr/local/bin/\(name)",
             "/usr/bin/\(name)"
         ]
-        // Try hardcoded paths first
         for path in homebrewPaths {
             if FileManager.default.isExecutableFile(atPath: path) {
                 return path
             }
         }
-        // Fall back to PATH lookup
         return ProcessInfo.processInfo.environment["PATH"]?
             .components(separatedBy: ":")
             .compactMap { URL(fileURLWithPath: $0).appendingPathComponent(name).path }
@@ -58,8 +81,10 @@ public actor FLACSplitter {
         try await withCheckedThrowingContinuation { cont in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: ffprobePath)
-            process.arguments = ["-v", "error", "-show_entries", "format=duration",
-                                  "-of", "default=noprint_wrappers=1:nokey=1", url.path]
+            process.arguments = [
+                "-v", "error", "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1", url.path
+            ]
             let pipe = Pipe()
             process.standardOutput = pipe
             process.standardError = FileHandle.nullDevice
@@ -80,12 +105,20 @@ public actor FLACSplitter {
         }
     }
 
+    /// Split an audio file into tracks using ffmpeg.
+    /// The output format always matches the input format (passthrough encoding).
     public func split(
         file inputURL: URL,
         tracks: [CueTrack],
         to outputDir: URL,
         progressHandler: @escaping @Sendable (Progress) -> Void
     ) async throws -> [URL] {
+        // Validate format is supported
+        let ext = inputURL.pathExtension.lowercased()
+        guard AudioFormat.fromExtension(ext) != nil else {
+            throw SplitError.unsupportedFormat(ext)
+        }
+
         let totalDuration = try await getDuration(of: inputURL)
 
         // Fill endSeconds for all tracks
@@ -101,31 +134,52 @@ public actor FLACSplitter {
         for track in filled {
             let duration = track.endSeconds! - track.startSeconds
             let safe = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
-            let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).flac")
+            let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).\(ext)")
 
             let progress = Progress(track: track.index, total: filled.count,
                                     trackTitle: track.title, secondsProcessed: track.startSeconds)
             Task { @Sendable in progressHandler(progress) }
 
+            // Use -acodec copy (passthrough) to avoid re-encoding — works for most formats
             try await runFFmpeg(input: inputURL, start: track.startSeconds,
-                                duration: duration, output: outURL)
+                                duration: duration, output: outURL, format: ext)
             outputs.append(outURL)
         }
 
         return outputs
     }
 
-    private func runFFmpeg(input: URL, start: Double, duration: Double, output: URL) async throws {
+    private func runFFmpeg(input: URL, start: Double, duration: Double,
+                           output: URL, format: String) async throws {
+        // Try stream copy first (-acodec copy)
+        do {
+            try await runFFmpegOnce(input: input, start: start, duration: duration,
+                                    output: output, extraArgs: ["-acodec", "copy"])
+        } catch {
+            // If stream copy fails (e.g., format doesn't support it), fall back to PCM WAV
+            // and rename to the target extension
+            try? FileManager.default.removeItem(at: output)
+            let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
+            try await runFFmpegOnce(input: input, start: start, duration: duration,
+                                    output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"])
+            // Rename .wav to target format extension
+            if FileManager.default.fileExists(atPath: fallbackURL.path) {
+                try FileManager.default.moveItem(at: fallbackURL, to: output)
+            }
+        }
+    }
+
+    /// Run ffmpeg once with given arguments; throws on failure.
+    private func runFFmpegOnce(input: URL, start: Double, duration: Double,
+                               output: URL, extraArgs: [String]) async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: ffmpegPath)
             process.arguments = [
                 "-y", "-i", input.path,
                 "-ss", String(format: "%.3f", start),
-                "-t",  String(format: "%.3f", duration),
-                "-acodec", "flac", "-compression_level", "8",
-                output.path
-            ]
+                "-t",  String(format: "%.3f", duration)
+            ] + extraArgs + [output.path]
             let errPipe = Pipe()
             process.standardOutput = FileHandle.nullDevice
             process.standardError = errPipe
@@ -147,7 +201,7 @@ public actor FLACSplitter {
     }
 
     private func sanitizeFilename(_ name: String) -> String {
-        let invalid = CharacterSet(charactersIn: "<>:\"'/\\|?*")
+        let invalid = CharacterSet(charactersIn: "<>:\"/'\\|?*")
         return name.components(separatedBy: invalid).joined(separator: "_").trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -106,22 +106,49 @@ public actor AudioSplitter {
     }
 
     /// Split an audio file into tracks using ffmpeg.
-    /// The output format always matches the input format (passthrough encoding).
+    /// - Parameters:
+    ///   - inputURL: Source audio file
+    ///   - tracks: Cue track definitions
+    ///   - outputDir: Destination directory
+    ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
+    ///     Pass `.flac` to re-encode any input to FLAC (lossless, smaller file).
+    ///     Pass `.wav` to re-encode to WAV (lossless PCM, larger file).
     public func split(
         file inputURL: URL,
         tracks: [CueTrack],
         to outputDir: URL,
+        outputFormat: AudioFormat? = nil,
         progressHandler: @escaping @Sendable (Progress) -> Void
     ) async throws -> [URL] {
-        // Validate format is supported
-        let ext = inputURL.pathExtension.lowercased()
-        guard AudioFormat.fromExtension(ext) != nil else {
-            throw SplitError.unsupportedFormat(ext)
+        let inputExt = inputURL.pathExtension.lowercased()
+        guard AudioFormat.fromExtension(inputExt) != nil else {
+            throw SplitError.unsupportedFormat(inputExt)
+        }
+
+        // Determine output extension
+        let outExt: String
+        let acodecArg: [String]
+        if let fmt = outputFormat {
+            outExt = fmt.rawValue
+            switch fmt {
+            case .flac:
+                acodecArg = ["-acodec", "flac"]
+            case .wav:
+                acodecArg = ["-acodec", "pcm_s16le"]
+            case .mp3:
+                acodecArg = ["-acodec", "libmp3lame"]
+            case .alac:
+                acodecArg = ["-acodec", "alac"]
+            default:
+                acodecArg = ["-acodec", "copy"]
+            }
+        } else {
+            outExt = inputExt
+            acodecArg = ["-acodec", "copy"]
         }
 
         let totalDuration = try await getDuration(of: inputURL)
 
-        // Fill endSeconds for all tracks
         var filled = tracks
         for i in 0..<filled.count {
             if filled[i].endSeconds == nil {
@@ -134,15 +161,14 @@ public actor AudioSplitter {
         for track in filled {
             let duration = track.endSeconds! - track.startSeconds
             let safe = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
-            let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).\(ext)")
+            let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).\(outExt)")
 
             let progress = Progress(track: track.index, total: filled.count,
                                     trackTitle: track.title, secondsProcessed: track.startSeconds)
             Task { @Sendable in progressHandler(progress) }
 
-            // Use -acodec copy (passthrough) to avoid re-encoding — works for most formats
             try await runFFmpeg(input: inputURL, start: track.startSeconds,
-                                duration: duration, output: outURL, format: ext)
+                                duration: duration, output: outURL, acodecArgs: acodecArg)
             outputs.append(outURL)
         }
 
@@ -150,22 +176,30 @@ public actor AudioSplitter {
     }
 
     private func runFFmpeg(input: URL, start: Double, duration: Double,
-                           output: URL, format: String) async throws {
-        // Try stream copy first (-acodec copy)
-        do {
-            try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                    output: output, extraArgs: ["-acodec", "copy"])
-        } catch {
-            // If stream copy fails (e.g., format doesn't support it), fall back to PCM WAV
-            // and rename to the target extension
-            try? FileManager.default.removeItem(at: output)
-            let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
-            try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                    output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"])
-            // Rename .wav to target format extension
-            if FileManager.default.fileExists(atPath: fallbackURL.path) {
-                try FileManager.default.moveItem(at: fallbackURL, to: output)
+                           output: URL, acodecArgs: [String]) async throws {
+        let isPassthrough = acodecArgs.first == "-acodec" && acodecArgs.last == "copy"
+
+        if isPassthrough {
+            // Try stream copy first (no re-encode)
+            do {
+                try await runFFmpegOnce(input: input, start: start, duration: duration,
+                                        output: output, extraArgs: acodecArgs)
+                return
+            } catch {
+                // Stream copy failed — fall back to PCM WAV, then rename
+                try? FileManager.default.removeItem(at: output)
+                let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
+                try await runFFmpegOnce(input: input, start: start, duration: duration,
+                                        output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"])
+                if FileManager.default.fileExists(atPath: fallbackURL.path) {
+                    try FileManager.default.moveItem(at: fallbackURL, to: output)
+                }
+                return
             }
+        } else {
+            // Explicit codec requested (FLAC/WAV/MP3 etc.) — no stream copy fallback
+            try await runFFmpegOnce(input: input, start: start, duration: duration,
+                                    output: output, extraArgs: acodecArgs)
         }
     }
 

--- a/Library/CueParser.swift
+++ b/Library/CueParser.swift
@@ -153,36 +153,97 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
 }
 
 /// Find the .cue file corresponding to an audio URL.
-/// For FLAC files, tries filename-based lookup first; for all formats,
-/// falls back to scanning all .cue files and validating via the FILE field.
+/// Tries filename-based match first; falls back to scanning all .cue files
+/// and using fuzzy FILE-field matching (handles Chinese encoding mismatches).
 public func findCue(for audioURL: URL) -> URL? {
     let dir = audioURL.deletingLastPathComponent()
     let base = audioURL.deletingPathExtension().lastPathComponent
 
-    // Try filename-based match (works for FLAC when cue shares the same base name)
+    // Try filename-based match
     for ext in ["cue", "CUE", "Cue"] {
         let candidate = dir.appendingPathComponent(base).appendingPathExtension(ext)
         if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
     }
 
-    // Fallback: scan all .cue files in the directory and match via CUE FILE field
+    // Fallback: scan all .cue files and use fuzzy FILE-field matching
     guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else {
         return nil
     }
+    var bestCandidate: URL?
+    var bestScore: Double = 0
+
     for entry in entries {
         let ext = (entry as NSString).pathExtension.lowercased()
         if ext != "cue" { continue }
         let cueURL = dir.appendingPathComponent(entry)
-        // Validate by parsing the FILE field via the existing parseCue function
-        if let (tracks, _, _, cueFile, _) = try? parseCue(at: cueURL),
-           !tracks.isEmpty,
-           let cf = cueFile,
-           cf.resolvedURL.lastPathComponent == audioURL.lastPathComponent {
-            return cueURL
+        guard let (tracks, _, _, cueFile, _) = try? parseCue(at: cueURL),
+              !tracks.isEmpty,
+              let cf = cueFile else { continue }
+
+        let score = stringSimilarity(cf.resolvedURL.lastPathComponent,
+                                      audioURL.lastPathComponent)
+        if score > bestScore {
+            bestScore = score
+            bestCandidate = cueURL
         }
     }
 
+    // Require at least 80% similarity
+    if bestScore >= 0.80 {
+        return bestCandidate
+    }
+
+    // Fallback: return best candidate if nothing matches 80% but the base names do
+    if let best = bestCandidate,
+       bestScore >= 0.60,
+       cfBaseNameMatches(best, audioURL) {
+        return best
+    }
+
     return nil
+}
+
+/// Check if the CUE's FILE field base name (without extension) broadly matches the audio file.
+/// Allows through cases where encoding garbled only the Chinese characters.
+private func cfBaseNameMatches(_ cueURL: URL, _ audioURL: URL) -> Bool {
+    guard let (tracks, _, _, cueFile, _) = try? parseCue(at: cueURL),
+          !tracks.isEmpty,
+          let cf = cueFile else { return false }
+    let cueBase = cf.resolvedURL.deletingPathExtension().lastPathComponent
+    let audioBase = audioURL.deletingPathExtension().lastPathComponent
+    // Strip common Unicode-confusable chars and compare
+    let normalizedCue = cueBase.folding(options: .diacriticInsensitive, locale: .current)
+    let normalizedAudio = audioBase.folding(options: .diacriticInsensitive, locale: .current)
+    return stringSimilarity(normalizedCue, normalizedAudio) >= 0.60
+}
+
+/// Levenshtein-distance-based similarity ratio (0.0 – 1.0).
+func stringSimilarity(_ s1: String, _ s2: String) -> Double {
+    if s1 == s2 { return 1.0 }
+    let s1Arr = Array(s1)
+    let s2Arr = Array(s2)
+    let m = s1Arr.count
+    let n = s2Arr.count
+    if m == 0 || n == 0 { return 0.0 }
+
+    // Wagner-Fischer DP: O(mn) space → use two rows
+    var prev = Array(0...n)
+    var curr = [Int](repeating: 0, count: n + 1)
+
+    for i in 1...m {
+        curr[0] = i
+        for j in 1...n {
+            let cost = s1Arr[i-1] == s2Arr[j-1] ? 0 : 1
+            curr[j] = min(prev[j] + 1,        // deletion
+                          curr[j-1] + 1,       // insertion
+                          prev[j-1] + cost)     // substitution
+        }
+        swap(&prev, &curr)
+    }
+
+    let distance = prev[n]
+    let maxLen = max(m, n)
+    return 1.0 - (Double(distance) / Double(maxLen))
 }
 
 // MARK: - Private helpers

--- a/Library/CueParser.swift
+++ b/Library/CueParser.swift
@@ -152,14 +152,36 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
     return (tracks, albumTitle, performer, cueFile, rem)
 }
 
-/// Find the .cue file corresponding to a FLAC URL.
-public func findCue(for flacURL: URL) -> URL? {
-    let dir = flacURL.deletingLastPathComponent()
-    let base = flacURL.deletingPathExtension().lastPathComponent
+/// Find the .cue file corresponding to an audio URL.
+/// For FLAC files, tries filename-based lookup first; for all formats,
+/// falls back to scanning all .cue files and validating via the FILE field.
+public func findCue(for audioURL: URL) -> URL? {
+    let dir = audioURL.deletingLastPathComponent()
+    let base = audioURL.deletingPathExtension().lastPathComponent
+
+    // Try filename-based match (works for FLAC when cue shares the same base name)
     for ext in ["cue", "CUE", "Cue"] {
         let candidate = dir.appendingPathComponent(base).appendingPathExtension(ext)
         if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
     }
+
+    // Fallback: scan all .cue files in the directory and match via CUE FILE field
+    guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else {
+        return nil
+    }
+    for entry in entries {
+        let ext = (entry as NSString).pathExtension.lowercased()
+        if ext != "cue" { continue }
+        let cueURL = dir.appendingPathComponent(entry)
+        // Validate by parsing the FILE field via the existing parseCue function
+        if let (tracks, _, _, cueFile, _) = try? parseCue(at: cueURL),
+           !tracks.isEmpty,
+           let cf = cueFile,
+           cf.resolvedURL.lastPathComponent == audioURL.lastPathComponent {
+            return cueURL
+        }
+    }
+
     return nil
 }
 

--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -26,6 +26,8 @@ public actor MetadataEmbedder {
         public let succeeded: Int
         public let failed: Int
         public let failures: [String]
+        /// True if any file had cover art skipped (e.g., WAV doesn't support embedded cover art).
+        public let coverWasSkipped: Bool
 
         public var isFullySuccessful: Bool { failed == 0 }
         public var isPartiallySuccessful: Bool { succeeded > 0 && failed > 0 }
@@ -122,10 +124,16 @@ public actor MetadataEmbedder {
         var succeeded = 0
         var failed = 0
         var failures: [String] = []
+        var coverWasSkipped = false
 
         for line in stdout.components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
             if line.hasPrefix("DONE: ") {
                 succeeded += 1
+            } else if line.hasPrefix("SKIP: ") {
+                succeeded += 1
+                if line.contains("cover art skipped") {
+                    coverWasSkipped = true
+                }
             } else if line.hasPrefix("ERROR: ") {
                 failed += 1
                 failures.append(String(line.dropFirst(7)))
@@ -137,7 +145,8 @@ public actor MetadataEmbedder {
             failures = ["脚本执行失败（RC=\(rc)）：\(stderr.prefix(100))"]
         }
 
-        return EmbedResult(total: files.count, succeeded: succeeded, failed: failed, failures: failures)
+        return EmbedResult(total: files.count, succeeded: succeeded, failed: failed,
+                           failures: failures, coverWasSkipped: coverWasSkipped)
     }
 
     private func runScript(jsonFile: URL) async throws -> (stdout: String, stderr: String, rc: Int32) {

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -55,8 +55,12 @@ public actor TrackSplitterEngine {
     }
 
     /// Process an audio file + CUE sheet and produce individual track files with metadata.
-    /// Supported input formats: FLAC, MP3, WAV, AIFF, ALAC, M4A, AAC, OGG, Opus.
-    public func process(inputURL: URL) async throws -> Result {
+    /// - Parameters:
+    ///   - inputURL: Source audio file
+    ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
+    ///     `.flac` = re-encode to FLAC (lossless, smaller file).
+    ///     `.wav` = re-encode to WAV (lossless PCM, larger file).
+    public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async throws -> Result {
         log("📂 Input: \(inputURL.lastPathComponent)")
 
         // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
@@ -70,12 +74,15 @@ public actor TrackSplitterEngine {
         log("🎵 Tracks: \(tracks.count) | Album: \(albumTitle ?? "—") | Artist: \(performer ?? "—")")
         log("📋 REM: date=\(cueRem.date ?? "—") genre=\(cueRem.genre ?? "—") comment=\(cueRem.comment ?? "—") composer=\(cueRem.composer ?? "—") discNumber=\(cueRem.discNumber ?? "—")")
 
-        // 2b. Validate FILE field if present
+        // 2b. Validate FILE field if present — use fuzzy match to handle encoding mismatches
         if let cf = cueFile {
             let cueDeclaredName = cf.resolvedURL.lastPathComponent
-            if cueDeclaredName != inputURL.lastPathComponent {
-                log("⚠️  CUE FILE mismatch — CUE: \"\(cf.path)\", actual: \"\(inputURL.lastPathComponent)\"")
+            let similarity = stringSimilarity(cueDeclaredName, inputURL.lastPathComponent)
+            if similarity < 0.80 {
+                log("⚠️  CUE FILE mismatch — CUE: \"\(cf.path)\", actual: \"\(inputURL.lastPathComponent)\" (similarity: \(String(format: "%.0f", similarity * 100))%)")
                 throw EngineError.cueFileMismatch(cueDeclaredFile: cf.path, actualAudioFile: inputURL.lastPathComponent)
+            } else {
+                log("📋 CUE FILE field similarity: \(String(format: "%.0f", similarity * 100))% — fuzzy-matched (encoding may differ)")
             }
         }
 
@@ -108,7 +115,8 @@ public actor TrackSplitterEngine {
             splitTracks = try await splitter.split(
                 file: inputURL,
                 tracks: tracks,
-                to: outDir
+                to: outDir,
+                outputFormat: outputFormat
             ) { [weak self] progress in
                 Task { await self?.log("  Splitting track \(progress.track)/\(progress.total): \(progress.trackTitle)...") }
             }
@@ -150,7 +158,7 @@ public actor TrackSplitterEngine {
 
         return Result(outputDirectory: outDir, trackFiles: splitTracks,
                       albumTitle: albumTitle, performer: performer,
-                      coverEmbedded: coverData != nil,
+                      coverEmbedded: coverData != nil && !metadataResult.coverWasSkipped,
                       metadataResult: metadataResult)
     }
 }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -102,7 +102,7 @@ public actor TrackSplitterEngine {
         var coverData: Data? = nil
         do {
             log("🖼  Fetching album cover...")
-            coverData = try await fetcher.fetch(artist: performer, album: albumTitle ?? albumDirName)
+            coverData = try await fetcher.fetch(artist: performer, album: albumTitle ?? albumDirName, inputFile: inputURL)
             log("✅  Cover art: \(coverData.map { "\($0.count) bytes" } ?? "none")")
         } catch {
             log("⚠️  Cover fetch failed (continuing without cover): \(error.localizedDescription)")

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -9,7 +9,7 @@ public actor TrackSplitterEngine {
         case outputDirCreationFailed
         case splittingFailed(String)
         case metadataFailed(String)
-        case cueFileMismatch(cueDeclaredFile: String, actualFlacFile: String)
+        case cueFileMismatch(cueDeclaredFile: String, actualAudioFile: String)
 
         public var errorDescription: String? {
             switch self {
@@ -18,8 +18,8 @@ public actor TrackSplitterEngine {
             case .outputDirCreationFailed: return "Failed to create output directory"
             case .splittingFailed(let msg): return "Splitting failed: \(msg)"
             case .metadataFailed(let msg): return "Metadata embedding failed: \(msg)"
-            case .cueFileMismatch(let cueDeclaredFile, let actualFlacFile):
-                return "CUE FILE field mismatch: CUE declares \"\(cueDeclaredFile)\" but input is \"\(actualFlacFile)\". Please ensure the FILE field in the CUE matches the actual audio file."
+            case .cueFileMismatch(let cueDeclaredFile, let actualAudioFile):
+                return "CUE FILE field mismatch: CUE declares \"\(cueDeclaredFile)\" but input is \"\(actualAudioFile)\". Please ensure the FILE field in the CUE matches the actual audio file."
             }
         }
     }
@@ -41,7 +41,7 @@ public actor TrackSplitterEngine {
         public func log(_ msg: String) { callback(msg) }
     }
 
-    private let splitter = FLACSplitter()
+    private let splitter = AudioSplitter()
     private let fetcher  = AlbumArtFetcher()
     private let embedder = MetadataEmbedder()
     private let logHandler: LogHandler?
@@ -54,13 +54,14 @@ public actor TrackSplitterEngine {
         logHandler?.log(msg)
     }
 
-    /// Process a FLAC+CUE pair and produce individual track FLAC files with metadata.
-    public func process(flacURL: URL) async throws -> Result {
-        log("📂 Input: \(flacURL.lastPathComponent)")
+    /// Process an audio file + CUE sheet and produce individual track files with metadata.
+    /// Supported input formats: FLAC, MP3, WAV, AIFF, ALAC, M4A, AAC, OGG, Opus.
+    public func process(inputURL: URL) async throws -> Result {
+        log("📂 Input: \(inputURL.lastPathComponent)")
 
-        // 1. Find CUE
-        guard let cueURL = findCue(for: flacURL) else {
-            throw EngineError.noCueFile(flacURL)
+        // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
+        guard let cueURL = findCue(for: inputURL) else {
+            throw EngineError.noCueFile(inputURL)
         }
         log("📋 CUE found: \(cueURL.lastPathComponent)")
 
@@ -72,17 +73,17 @@ public actor TrackSplitterEngine {
         // 2b. Validate FILE field if present
         if let cf = cueFile {
             let cueDeclaredName = cf.resolvedURL.lastPathComponent
-            if cueDeclaredName != flacURL.lastPathComponent {
-                log("⚠️  CUE FILE mismatch — CUE: \"\(cf.path)\", actual: \"\(flacURL.lastPathComponent)\"")
-                throw EngineError.cueFileMismatch(cueDeclaredFile: cf.path, actualFlacFile: flacURL.lastPathComponent)
+            if cueDeclaredName != inputURL.lastPathComponent {
+                log("⚠️  CUE FILE mismatch — CUE: \"\(cf.path)\", actual: \"\(inputURL.lastPathComponent)\"")
+                throw EngineError.cueFileMismatch(cueDeclaredFile: cf.path, actualAudioFile: inputURL.lastPathComponent)
             }
         }
 
         guard !tracks.isEmpty else { throw EngineError.emptyTracks }
 
         // 3. Create output directory
-        let albumDirName = albumTitle ?? flacURL.deletingPathExtension().lastPathComponent
-        let outDir = flacURL.deletingLastPathComponent().appendingPathComponent(albumDirName)
+        let albumDirName = albumTitle ?? inputURL.deletingPathExtension().lastPathComponent
+        let outDir = inputURL.deletingLastPathComponent().appendingPathComponent(albumDirName)
         do {
             try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
         } catch {
@@ -100,12 +101,12 @@ public actor TrackSplitterEngine {
             log("⚠️  Cover fetch failed (continuing without cover): \(error.localizedDescription)")
         }
 
-        // 5. Split FLAC
+        // 5. Split audio
         log("✂️  Starting split with ffmpeg...")
         let splitTracks: [URL]
         do {
             splitTracks = try await splitter.split(
-                file: flacURL,
+                file: inputURL,
                 tracks: tracks,
                 to: outDir
             ) { [weak self] progress in

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
             sources: [
                 "CueParser.swift",
                 "AlbumArtFetcher.swift",
-                "FLACSplitter.swift",
+                "AudioSplitter.swift",
                 "MetadataEmbedder.swift",
                 "TrackSplitterEngine.swift",
             ]

--- a/Resources/embed_metadata.py
+++ b/Resources/embed_metadata.py
@@ -1,7 +1,27 @@
 #!/usr/bin/env python3
-"""Embed metadata into FLAC files. Called from Swift via Process."""
-import sys, os, json, base64
-from mutagen.flac import FLAC, Picture
+"""Embed metadata into audio files. Supports FLAC, MP3, AAC/M4A via mutagen; WAV via ffmpeg."""
+import sys, os, json, base64, subprocess, shlex
+
+# mutagen supported formats
+try:
+    from mutagen.flac import FLAC, Picture as FLACPicture
+    HAS_FLAC = True
+except ImportError:
+    HAS_FLAC = False
+
+try:
+    from mutagen.mp3 import MP3
+    from mutagen.id3 import ID3, TYER, TIT2, TPE1, TALB, TRCK, TCON, COMM, TPE2, TDRC
+    HAS_MP3 = True
+except ImportError:
+    HAS_MP3 = False
+
+try:
+    from mutagen.mp4 import MP4
+    HAS_MP4 = True
+except ImportError:
+    HAS_MP4 = False
+
 
 def main():
     if len(sys.argv) < 2:
@@ -10,19 +30,20 @@ def main():
 
     json_path = sys.argv[1]
     if not os.path.exists(json_path):
-        print("ERROR: JSON file not found: %s" % json_path)
+        print("ERROR: JSON file not found: %s" % json_path, file=sys.stderr)
         sys.exit(1)
 
     try:
         payload = json.load(open(json_path))
     except Exception as e:
-        print("ERROR: JSON load error: %s" % e)
+        print("ERROR: JSON load error: %s" % e, file=sys.stderr)
         sys.exit(1)
 
+    cover_b64 = payload.get("coverData")
     cover_bytes = None
-    if payload.get("coverData"):
+    if cover_b64:
         try:
-            cover_bytes = base64.b64decode(payload["coverData"])
+            cover_bytes = base64.b64decode(cover_b64)
         except Exception:
             pass
 
@@ -32,39 +53,192 @@ def main():
             print("ERROR: %s: file not found" % os.path.basename(fpath))
             continue
 
-        try:
-            audio = FLAC(fpath)
-            audio.clear()
-            audio["TITLE"]       = item.get("title", "")
-            audio["ARTIST"]      = item.get("artist", "")
-            audio["ALBUM"]       = item.get("album", "")
-            audio["DATE"]        = item.get("year", "")
-            audio["YEAR"]        = item.get("year", "")
-            audio["GENRE"]       = item.get("genre", "")
-            audio["TRACKNUMBER"] = item.get("tracknum", "")
-            audio["TOTALTRACKS"] = item.get("total", "")
-            audio["ALBUMARTIST"] = item.get("artist", "")
+        ext = os.path.splitext(fpath)[1].lower()
+        ok = False
 
-            if item.get("comment"):
-                audio["COMMENT"] = item["comment"]
-            if item.get("composer"):
-                audio["COMPOSER"] = item["composer"]
-            if item.get("discNumber"):
-                audio["DISCNUMBER"] = item["discNumber"]
+        if ext == ".flac" and HAS_FLAC:
+            ok = embed_flac(fpath, item, cover_bytes)
+        elif ext == ".mp3" and HAS_MP3:
+            ok = embed_mp3(fpath, item, cover_bytes)
+        elif ext in (".m4a", ".aac", ".mp4") and HAS_MP4:
+            ok = embed_mp4(fpath, item, cover_bytes)
+        elif ext == ".wav":
+            ok = embed_wav(fpath, item, cover_bytes)
+        else:
+            # Fallback: try ffmpeg for any format
+            ok = embed_ffmpeg(fpath, item, cover_bytes)
 
-            if cover_bytes:
-                audio.clear_pictures()
-                pic = Picture()
-                pic.type = 3
-                pic.desc = "Album cover"
-                pic.mime = "image/jpeg"
-                pic.data = cover_bytes
-                audio.add_picture(pic)
-
-            audio.save()
+        if ok:
             print("DONE: %s" % os.path.basename(fpath))
-        except Exception as e:
-            print("ERROR: %s: %s" % (os.path.basename(fpath), e))
+        else:
+            print("ERROR: %s: embedding failed" % os.path.basename(fpath))
+
+
+def embed_flac(fpath: str, item: dict, cover_bytes: bytes) -> bool:
+    try:
+        audio = FLAC(fpath)
+        audio.clear()
+        set_tag(audio, "TITLE", item.get("title"))
+        set_tag(audio, "ARTIST", item.get("artist"))
+        set_tag(audio, "ALBUM", item.get("album"))
+        set_tag(audio, "DATE", item.get("year"))
+        set_tag(audio, "YEAR", item.get("year"))
+        set_tag(audio, "GENRE", item.get("genre"))
+        set_tag(audio, "TRACKNUMBER", item.get("tracknum"))
+        set_tag(audio, "TOTALTRACKS", item.get("total"))
+        set_tag(audio, "ALBUMARTIST", item.get("artist"))
+        if item.get("comment"):
+            set_tag(audio, "COMMENT", item["comment"])
+        if item.get("composer"):
+            set_tag(audio, "COMPOSER", item["composer"])
+        if item.get("discNumber"):
+            set_tag(audio, "DISCNUMBER", item["discNumber"])
+        if cover_bytes:
+            audio.clear_pictures()
+            pic = FLACPicture()
+            pic.type = 3
+            pic.desc = "Album cover"
+            pic.mime = "image/jpeg"
+            pic.data = cover_bytes
+            audio.add_picture(pic)
+        audio.save()
+        return True
+    except Exception as e:
+        print("ERROR: %s: %s" % (os.path.basename(fpath), e))
+        return False
+
+
+def embed_mp3(fpath: str, item: dict, cover_bytes: bytes) -> bool:
+    try:
+        audio = MP3(fpath)
+        if audio.tags is None:
+            audio.add_tags()
+        id3 = audio.tags
+
+        set_id3(id3, "TIT2", item.get("title"))          # title
+        set_id3(id3, "TPE1", item.get("artist"))         # artist
+        set_id3(id3, "TALB", item.get("album"))          # album
+        set_id3(id3, "TYER", item.get("year"))           # year
+        set_id3(id3, "TDRC", item.get("year"))           # year (id3v2.4)
+        set_id3(id3, "TCON", item.get("genre"))          # genre
+        set_id3(id3, "TRCK", item.get("tracknum"))       # track
+        if item.get("comment"):
+            set_id3(id3, "COMM", item["comment"])         # comment
+        if item.get("composer"):
+            set_id3(id3, "TPE2", item["composer"])        # album artist / composer
+        if item.get("discNumber"):
+            pass  # MP3 doesn't have standard DISCNUMBER tag in basic set
+        id3.save()
+        return True
+    except Exception as e:
+        print("ERROR: %s: %s" % (os.path.basename(fpath), e))
+        return False
+
+
+def embed_mp4(fpath: str, item: dict, cover_bytes: bytes) -> bool:
+    try:
+        audio = MP4(fpath)
+        audio["\xa9nam"] = item.get("title", "")         # title
+        audio["\xa9ART"] = item.get("artist", "")         # artist
+        audio["\xa9alb"] = item.get("album", "")          # album
+        audio["\xa9day"] = item.get("year", "")          # year
+        audio["\xa9gen"] = item.get("genre", "")          # genre
+        audio["trkn"] = [(int(item.get("tracknum", 0)), int(item.get("total", 0)))]
+        if item.get("comment"):
+            audio["\xa9cmt"] = item["comment"]
+        # cover art: MP4 uses covr atom
+        if cover_bytes:
+            audio["covr"] = [cover_bytes]
+        audio.save()
+        return True
+    except Exception as e:
+        print("ERROR: %s: %s" % (os.path.basename(fpath), e))
+        return False
+
+
+def _ffmpeg_cmd():
+    """Return full path to ffmpeg, matching MetadataEmbedder's lookup order."""
+    import shutil
+    for path in ("/opt/homebrew/bin/ffmpeg", "/opt/homebrew/bin/ffmpeg3",
+                 "/usr/local/bin/ffmpeg", "/usr/bin/ffmpeg", "ffmpeg"):
+        if shutil.which(path) or path == "ffmpeg":
+            return path
+    return "ffmpeg"
+
+
+def embed_wav(fpath: str, item: dict, cover_bytes: bytes) -> bool:
+    """Write basic metadata to WAV using ffmpeg -metadata.
+    WAV does not support embedded cover art."""
+    ffmpeg = _ffmpeg_cmd()
+    cmd = [
+        ffmpeg, "-y",
+        "-i", fpath,
+        "-metadata", "title=" + (item.get("title") or ""),
+        "-metadata", "artist=" + (item.get("artist") or ""),
+        "-metadata", "album=" + (item.get("album") or ""),
+        "-metadata", "year=" + (item.get("year") or ""),
+        "-metadata", "genre=" + (item.get("genre") or ""),
+        "-metadata", "comment=" + (item.get("comment") or ""),
+        "-codec", "copy",
+        fpath + ".tmp.wav"
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, timeout=30)
+        if proc.returncode == 0:
+            os.replace(fpath + ".tmp.wav", fpath)
+            # WAV has no cover art support
+            if cover_bytes:
+                print("SKIP: %s: cover art skipped (WAV format does not support embedded images)" % os.path.basename(fpath))
+            return True
+        else:
+            err = proc.stderr.decode()[:200] if proc.stderr else "unknown"
+            print("ERROR: %s: ffmpeg failed: %s" % (os.path.basename(fpath), err))
+            if os.path.exists(fpath + ".tmp.wav"):
+                os.remove(fpath + ".tmp.wav")
+            return False
+    except Exception as e:
+        print("ERROR: %s: %s" % (os.path.basename(fpath), e))
+        return False
+
+
+def embed_ffmpeg(fpath: str, item: dict, cover_bytes: bytes) -> bool:
+    """Generic fallback: ffmpeg -metadata for any format (no cover art)."""
+    ffmpeg = _ffmpeg_cmd()
+    cmd = [
+        ffmpeg, "-y",
+        "-i", fpath,
+        "-metadata", "title=" + (item.get("title") or ""),
+        "-metadata", "artist=" + (item.get("artist") or ""),
+        "-metadata", "album=" + (item.get("album") or ""),
+        "-metadata", "year=" + (item.get("year") or ""),
+        "-metadata", "genre=" + (item.get("genre") or ""),
+        "-metadata", "comment=" + (item.get("comment") or ""),
+        "-codec", "copy",
+        fpath + ".tmp"
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, timeout=30)
+        if proc.returncode == 0:
+            os.replace(fpath + ".tmp", fpath)
+            return True
+        else:
+            if os.path.exists(fpath + ".tmp"):
+                os.remove(fpath + ".tmp")
+            return False
+    except Exception as e:
+        print("ERROR: %s: %s" % (os.path.basename(fpath), e))
+        return False
+
+
+def set_tag(audio, key: str, value: str):
+    if value:
+        audio[key] = value
+
+
+def set_id3(id3, key: str, value: str):
+    if value:
+        id3[key] = value
+
 
 if __name__ == "__main__":
     main()

--- a/ViewModels/SplitterViewModel.swift
+++ b/ViewModels/SplitterViewModel.swift
@@ -9,17 +9,17 @@ final class SplitterViewModel: ObservableObject {
     /// 全局应用状态。
     let appState = AppState()
 
-    /// 处理用户选择或拖入的 FLAC 文件。
-    func load(flacURL: URL) {
-        // 仅允许 .flac 扩展名，避免误处理其它音频格式。
-        guard flacURL.pathExtension.lowercased() == "flac" else {
-            appState.setError("仅支持 .flac 文件")
+    /// 处理用户选择或拖入的音频文件。
+    func load(audioURL: URL) {
+        let supported: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
+        guard supported.contains(audioURL.pathExtension.lowercased()) else {
+            appState.setError("不支持的文件格式。支持：FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus")
             return
         }
 
-        // 自动查找同名 CUE 文件。
-        guard let cueURL = findCue(for: flacURL) else {
-            appState.setError("未找到同名 CUE 文件：\(flacURL.deletingPathExtension().lastPathComponent).cue")
+        // 自动查找匹配的 CUE 文件。
+        guard let cueURL = findCue(for: audioURL) else {
+            appState.setError("未找到匹配的 CUE 文件（请确认 CUE 中 FILE 字段与音频文件名一致）")
             return
         }
 
@@ -28,7 +28,7 @@ final class SplitterViewModel: ObservableObject {
             let (tracks, albumTitle, performer, _, _) = try parseCue(at: cueURL)
             let previewTracks = fillPreviewEndTimes(for: tracks)
             let loaded = AppState.LoadedFiles(
-                flacURL: flacURL,
+                audioURL: audioURL,
                 cueURL: cueURL,
                 tracks: previewTracks,
                 albumTitle: albumTitle,
@@ -65,7 +65,7 @@ final class SplitterViewModel: ObservableObject {
         Task {
             do {
                 let engine = TrackSplitterEngine(logHandler: logHandler)
-                let result = try await engine.process(flacURL: loaded.flacURL)
+                let result = try await engine.process(inputURL: loaded.audioURL)
                 let completion = AppState.Completion(
                     outputDirectory: result.outputDirectory,
                     trackFiles: result.trackFiles,

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -60,13 +60,13 @@ struct ContentView: View {
         VStack(alignment: .leading, spacing: 14) {
             // 拖放区：始终显示，允许重新选择文件
             DropZoneView { fileURL in
-                viewModel.load(flacURL: fileURL)
+                viewModel.load(audioURL: fileURL)
             }
 
             if let loaded {
                 // 文件信息区
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("已加载：\(loaded.flacURL.lastPathComponent)")
+                    Text("已加载：\(loaded.audioURL.lastPathComponent)")
                         .font(.headline)
                     Text("CUE：\(loaded.cueURL.lastPathComponent)")
                         .font(.subheadline)

--- a/Views/DropZoneView.swift
+++ b/Views/DropZoneView.swift
@@ -26,8 +26,22 @@ class DropZoneNSView: NSView {
         didSet { needsDisplay = true }
     }
 
-    /// FLAC 类型。
-    private let flacType = UTType(filenameExtension: "flac") ?? .data
+    /// 支持的音频格式列表。
+    private static let supportedExtensions: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
+
+    /// 支持的 UTType 列表。
+    private static var supportedTypes: [UTType] {
+        [
+            UTType(filenameExtension: "flac") ?? .data,
+            UTType(filenameExtension: "mp3") ?? .data,
+            UTType(filenameExtension: "wav") ?? .data,
+            UTType(filenameExtension: "aiff") ?? .data,
+            UTType(filenameExtension: "m4a") ?? .data,
+            UTType(filenameExtension: "aac") ?? .data,
+            UTType(filenameExtension: "ogg") ?? .data,
+            UTType(filenameExtension: "opus") ?? .data,
+        ]
+    }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -44,7 +58,7 @@ class DropZoneNSView: NSView {
         registerForDraggedTypes([.fileURL])
 
         // 添加"选择文件"按钮。
-        let button = NSButton(title: "选择 FLAC 文件", target: self, action: #selector(openFilePicker))
+        let button = NSButton(title: "选择音频文件", target: self, action: #selector(openFilePicker))
         button.bezelStyle = .rounded
         button.controlSize = .large
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -65,9 +79,9 @@ class DropZoneNSView: NSView {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [flacType]
-        panel.title = "选择 FLAC 文件"
-        panel.message = "请选择要拆分的 FLAC 文件"
+        panel.allowedContentTypes = Self.supportedTypes
+        panel.title = "选择音频文件"
+        panel.message = "请选择要拆分的音频文件（FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus）"
 
         // 设置为 sheet 模式，避免阻塞主事件循环。
         if let window = self.window {
@@ -90,13 +104,13 @@ class DropZoneNSView: NSView {
     // MARK: - 拖放支持
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard hasValidFlacFile(sender) else { return [] }
+        guard hasValidAudioFile(sender) else { return [] }
         isDragHighlighted = true
         return .copy
     }
 
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        hasValidFlacFile(sender) ? .copy : []
+        hasValidAudioFile(sender) ? .copy : []
     }
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
@@ -104,32 +118,32 @@ class DropZoneNSView: NSView {
     }
 
     override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        hasValidFlacFile(sender)
+        hasValidAudioFile(sender)
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         isDragHighlighted = false
-        guard let fileURL = extractFlacFile(sender) else { return false }
+        guard let fileURL = extractAudioFile(sender) else { return false }
         fputs("[TrackSplitter] Dropped file: \(fileURL.path)\n", stderr)
         fflush(stderr)
         onFileSelected?(fileURL)
         return true
     }
 
-    /// 检查拖放数据中是否包含有效的 FLAC 文件。
-    private func hasValidFlacFile(_ info: NSDraggingInfo) -> Bool {
+    /// 检查拖放数据中是否包含有效的音频文件。
+    private func hasValidAudioFile(_ info: NSDraggingInfo) -> Bool {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return false
         }
-        return urls.contains { $0.pathExtension.lowercased() == "flac" }
+        return urls.contains { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
-    /// 从拖放数据中提取 FLAC 文件 URL。
-    private func extractFlacFile(_ info: NSDraggingInfo) -> URL? {
+    /// 从拖放数据中提取音频文件 URL。
+    private func extractAudioFile(_ info: NSDraggingInfo) -> URL? {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return nil
         }
-        return urls.filter { $0.pathExtension.lowercased() == "flac" }.first
+        return urls.first { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 
     // MARK: - 绘制
@@ -170,7 +184,7 @@ class DropZoneNSView: NSView {
             .paragraphStyle: paragraphStyle
         ]
         let textRect = NSRect(x: 0, y: bounds.midY - 40, width: bounds.width, height: 20)
-        "拖放 FLAC 文件到此处".draw(in: textRect, withAttributes: textAttrs)
+        "拖放音频文件到此处".draw(in: textRect, withAttributes: textAttrs)
     }
 }
 


### PR DESCRIPTION
## 改动内容

支持多种输入音频格式，关联 issue #12。

### 核心改动

- `AudioSplitter`（原 FLACSplitter）：泛化支持所有 ffmpeg 原生可读格式：FLAC, MP3, WAV, AIFF, ALAC, M4A, AAC, OGG, Opus。输出格式自动与输入一致（-acodec copy），不支持流拷贝时降级为 PCM WAV 再改名。
- `findCue()`：对非 FLAC 文件，fallback 逻辑改为扫描同目录所有 .cue 并用 CUE FILE 字段校验，不再依赖文件名匹配。
- `process(flacURL:)` → `process(inputURL:)`：引擎、CLI、GUI 全链路参数改名。
- `DropZoneView`：UTType 列表扩展至全部支持格式，文件选择器标题/提示文字更新。
- CLI：帮助文本和格式校验扩展为多格式。

### 验证

- swift build ✅
- xcodebuild (GUI app) ✅

### 关联 issue

Closes #12
