### PR TITLE
fix: passthrough-failure fallback preserves extension/codec consistency (issue #16)

### DIFF
--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -54,9 +54,12 @@ public actor AudioSplitter {
     private let ffmpegPath: String
     private let ffprobePath: String
 
-    public init() {
-        self.ffmpegPath = Self.findBinary("ffmpeg") ?? "/usr/local/bin/ffmpeg"
-        self.ffprobePath = Self.findBinary("ffprobe") ?? "/usr/local/bin/ffprobe"
+    /// - Parameters:
+    ///   - ffmpegPath: Optional override for the ffmpeg binary path (useful for testing).
+    ///   - ffprobePath: Optional override for the ffprobe binary path (useful for testing).
+    public init(ffmpegPath: String? = nil, ffprobePath: String? = nil) {
+        self.ffmpegPath = ffmpegPath ?? Self.findBinary("ffmpeg") ?? "/usr/local/bin/ffmpeg"
+        self.ffprobePath = ffprobePath ?? Self.findBinary("ffprobe") ?? "/usr/local/bin/ffprobe"
     }
 
     private static func findBinary(_ name: String) -> String? {
@@ -167,16 +170,19 @@ public actor AudioSplitter {
                                     trackTitle: track.title, secondsProcessed: track.startSeconds)
             Task { @Sendable in progressHandler(progress) }
 
-            try await runFFmpeg(input: inputURL, start: track.startSeconds,
+            // runFFmpeg returns the actual URL written (may differ if passthrough fell back to WAV)
+            let actualURL = try await runFFmpeg(input: inputURL, start: track.startSeconds,
                                 duration: duration, output: outURL, acodecArgs: acodecArg)
-            outputs.append(outURL)
+            outputs.append(actualURL)
         }
 
         return outputs
     }
 
+    /// Runs ffmpeg and returns the actual URL that was written.
+    /// If passthrough fails, falls back to PCM WAV — extension stays .wav to match actual codec.
     private func runFFmpeg(input: URL, start: Double, duration: Double,
-                           output: URL, acodecArgs: [String]) async throws {
+                           output: URL, acodecArgs: [String]) async throws -> URL {
         let isPassthrough = acodecArgs.first == "-acodec" && acodecArgs.last == "copy"
 
         if isPassthrough {
@@ -184,22 +190,21 @@ public actor AudioSplitter {
             do {
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
                                         output: output, extraArgs: acodecArgs)
-                return
+                return output
             } catch {
-                // Stream copy failed — fall back to PCM WAV, then rename
+                // Stream copy failed — fall back to PCM WAV.
+                // Extension stays .wav to match actual codec; no rename back to original ext.
                 try? FileManager.default.removeItem(at: output)
                 let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
                                         output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"])
-                if FileManager.default.fileExists(atPath: fallbackURL.path) {
-                    try FileManager.default.moveItem(at: fallbackURL, to: output)
-                }
-                return
+                return fallbackURL
             }
         } else {
             // Explicit codec requested (FLAC/WAV/MP3 etc.) — no stream copy fallback
             try await runFFmpegOnce(input: input, start: start, duration: duration,
                                     output: output, extraArgs: acodecArgs)
+            return output
         }
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,12 @@ let package = Package(
                 "Views/ResultView.swift",
                 "ViewModels/SplitterViewModel.swift",
             ]
+        ),
+        .testTarget(
+            name: "TrackSplitterTests",
+            dependencies: ["TrackSplitterLib"],
+            path: "Tests",
+            sources: ["AudioSplitterTests.swift"]
         )
     ]
 )

--- a/Tests/AudioSplitterTests.swift
+++ b/Tests/AudioSplitterTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+@testable import TrackSplitterLib
+import XCTest
+
+/// Tests for AudioSplitter, focused on the passthrough-failure fallback path (issue #16).
+final class AudioSplitterTests: XCTestCase {
+
+    // MARK: - Passthrough-failure fallback: extension matches actual codec
+
+    /// When stream-copy passthrough fails, the fallback must produce a file whose extension
+    /// matches its actual codec (WAV), not rename it back to the original non-WAV extension.
+    func testPassthroughFailureFallbackExtensionMatchesActualCodec() async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let inputURL = tempDir.appendingPathComponent("input.flac")
+        try createMinimalFLAC(at: inputURL, durationSeconds: 10.0)
+
+        // Fake ffmpeg: exits 1 when "-acodec copy" is in args; writes a valid WAV otherwise.
+        let fakeFFmpegPath = try writeFakeFFmpegScript(failPassthrough: true)
+        let splitter = AudioSplitter(ffmpegPath: fakeFFmpegPath, ffprobePath: ffprobePath())
+
+        let tracks = [
+            CueTrack(index: 1, title: "Track One", startSeconds: 0, endSeconds: 10)
+        ]
+
+        let progressCalled = ThreadSafe(false)
+        let outputs = try await splitter.split(
+            file: inputURL,
+            tracks: tracks,
+            to: tempDir,
+            outputFormat: nil,
+            progressHandler: { _ in progressCalled.value = true }
+        )
+
+        XCTAssertEqual(outputs.count, 1)
+        let actualURL = outputs[0]
+
+        // The fallback extension must be .wav (matches PCM codec), not .flac (the original ext)
+        XCTAssertEqual(actualURL.pathExtension, "wav",
+            "Fallback output URL must have .wav extension to match actual PCM codec")
+
+        // The file must actually exist
+        XCTAssertTrue(FileManager.default.fileExists(atPath: actualURL.path),
+            "Fallback output file must exist at \(actualURL.path)")
+
+        // Verify ffprobe reports WAV
+        let format = try probeFormat(of: actualURL)
+        XCTAssertTrue(format.lowercased().contains("wav"),
+            "ffprobe must report fallback file as WAV, got: \(format)")
+
+        XCTAssertTrue(progressCalled.value, "Progress handler should have been called")
+    }
+
+    /// When passthrough succeeds, the output URL must retain the original input extension.
+    func testPassthroughSuccessPreservesOriginalExtension() async throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let inputURL = tempDir.appendingPathComponent("input.mp3")
+        try createMinimalMP3(at: inputURL, durationSeconds: 10.0)
+
+        // Fake ffmpeg: always succeeds, writes a valid WAV file.
+        let fakeFFmpegPath = try writeFakeFFmpegScript(failPassthrough: false)
+        let splitter = AudioSplitter(ffmpegPath: fakeFFmpegPath, ffprobePath: ffprobePath())
+
+        let tracks = [
+            CueTrack(index: 1, title: "Track One", startSeconds: 0, endSeconds: 10)
+        ]
+
+        let outputs = try await splitter.split(
+            file: inputURL,
+            tracks: tracks,
+            to: tempDir,
+            outputFormat: nil,
+            progressHandler: { _ in }
+        )
+
+        XCTAssertEqual(outputs.count, 1)
+        // On success, extension must match input (passthrough)
+        XCTAssertEqual(outputs[0].pathExtension, "mp3",
+            "Passthrough output must preserve original input extension")
+    }
+
+    // MARK: - Helpers
+
+    private func ffprobePath() -> String {
+        let candidates = ["/opt/homebrew/bin/ffprobe", "/usr/local/bin/ffprobe", "/usr/bin/ffprobe"]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? "ffprobe"
+    }
+
+    /// Writes a standalone Python script that acts as a fake ffmpeg binary.
+    /// failPassthrough=true  → exits 1 if "-acodec copy" appears in args
+    /// failPassthrough=false → always exits 0
+    /// In both cases writes a minimal valid WAV to the output path (last arg).
+    private func writeFakeFFmpegScript(failPassthrough: Bool) throws -> String {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let scriptPath = dir.appendingPathComponent("ffmpeg")
+
+        let pyBool = failPassthrough ? "True" : "False"
+        let pythonSrc = """
+        #!/usr/bin/env python3
+        import sys
+        args = sys.argv[1:]
+        if \(pyBool):
+            for i, a in enumerate(args):
+                if a == '-acodec' and i+1 < len(args) and args[i+1] == 'copy':
+                    sys.exit(1)
+        out = args[-1]
+        hdr = b'RIFF' + b'\\x24\\x02\\x00\\x00' + b'WAVEfmt \\x10\\x00\\x00\\x00\\x01\\x00\\x01\\x00@\\x1f\\x00\\x00@\\x1f\\x00\\x00\\x01\\x00\\x08\\x00' + b'data\\x00\\x02\\x00\\x00'
+        with open(out, 'wb') as f:
+            f.write(hdr)
+        sys.exit(0)
+        """
+
+        try pythonSrc.write(toFile: scriptPath.path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptPath.path)
+        return scriptPath.path
+    }
+
+    private func createMinimalFLAC(at url: URL, durationSeconds: Double) throws {
+        let ffmpeg = Process()
+        ffmpeg.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/ffmpeg")
+        ffmpeg.arguments = [
+            "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+            "-t", String(durationSeconds), "-acodec", "flac", url.path
+        ]
+        ffmpeg.standardOutput = FileHandle.nullDevice
+        ffmpeg.standardError = FileHandle.nullDevice
+        try ffmpeg.run()
+        ffmpeg.waitUntilExit()
+        if !FileManager.default.fileExists(atPath: url.path) {
+            throw NSError(domain: "Test", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create FLAC test file (exit: \(ffmpeg.terminationStatus))"])
+        }
+    }
+
+    private func createMinimalMP3(at url: URL, durationSeconds: Double) throws {
+        let ffmpeg = Process()
+        ffmpeg.executableURL = URL(fileURLWithPath: "/opt/homebrew/bin/ffmpeg")
+        ffmpeg.arguments = [
+            "-y", "-f", "lavfi", "-i", "anullsrc=r=44100:cl=mono",
+            "-t", String(durationSeconds), "-acodec", "libmp3lame", url.path
+        ]
+        ffmpeg.standardOutput = FileHandle.nullDevice
+        ffmpeg.standardError = FileHandle.nullDevice
+        try ffmpeg.run()
+        ffmpeg.waitUntilExit()
+        if !FileManager.default.fileExists(atPath: url.path) {
+            throw NSError(domain: "Test", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create MP3 test file (exit: \(ffmpeg.terminationStatus))"])
+        }
+    }
+
+    private func probeFormat(of url: URL) throws -> String {
+        let ffprobe = ffprobePath()
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: ffprobe)
+        proc.arguments = [
+            "-v", "error", "-show_entries", "format=format_name",
+            "-of", "default=noprint_wrappers=1:nokey=1", url.path
+        ]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        try proc.run()
+        proc.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}
+
+/// Thread-safe bool wrapper for capturing progress callback state.
+private final class ThreadSafe {
+    var value: Bool
+    init(_ value: Bool) { self.value = value }
+}


### PR DESCRIPTION
## Problem (issue #16)

When stream-copy passthrough fails, AudioSplitter falls back to PCM WAV encoding but then renames the .wav output back to the original file extension (e.g. .mp3, .m4a). Files end up with codec/extension mismatch — a hard correctness bug.

## Fix (Strategy 2)

Passthrough fails → fallback writes to a .wav URL directly. Extension stays consistent with actual codec. No rename back to the original extension.

### Changed files (3 total)
1. **Library/AudioSplitter.swift** — core fix
   - runFFmpeg() now returns the actual URL written (was void)
   - Passthrough success → returns original output URL
   - Passthrough failure → returns .wav URL (matches PCM codec)
   - Removed the erroneous FileManager.moveItem rename
2. **Package.swift** — added Tests/ test target
3. **Tests/AudioSplitterTests.swift** — two test cases:
   - testPassthroughFailureFallbackExtensionMatchesActualCodec
   - testPassthroughSuccessPreservesOriginalExtension

### Acceptance Criteria
- [x] Fallback creates no files whose format differs from extension
- [x] Codec and extension switch together (WAV → .wav)
- [x] Output files open correctly; ffprobe confirms format = extension
- [x] Metadata embedding uses the actual returned URL
- [x] Tests covering passthrough-failure scenario