### PR TITLE
fix #24: align CFBundleDocumentTypes with actual supported input formats

### DIFF
--- a/GUI/App/Info.plist
+++ b/GUI/App/Info.plist
@@ -48,6 +48,90 @@
                 <string>org.xiph.flac</string>
             </array>
         </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>MP3 Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.mp3</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>WAVE Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.microsoft.waveform-audio</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>AIFF Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.aiff-audio</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>M4A Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.m4a-audio</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>AAC Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.aac-audio</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>OGG Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>org.xiph.ogg</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Opus Audio</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>org.xiph.opus</string>
+            </array>
+        </dict>
     </array>
     <key>UTImportedTypeDeclarations</key>
     <array>
@@ -65,6 +149,40 @@
                 <key>public.filename-extension</key>
                 <array>
                     <string>flac</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>org.xiph.ogg</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.audio</string>
+            </array>
+            <key>UTTypeDescription</key>
+            <string>OGG Audio</string>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>ogg</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>org.xiph.opus</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.audio</string>
+            </array>
+            <key>UTTypeDescription</key>
+            <string>Opus Audio</string>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key>
+                <array>
+                    <string>opus</string>
                 </array>
             </dict>
         </dict>


### PR DESCRIPTION
## 背景
issue #24: macOS 应用文件类型声明与实际支持的输入格式不一致

代码层面 GUI 声称支持 9 种格式（flac, mp3, wav, aiff, alac, m4a, aac, ogg, opus），但 Info.plist 的 CFBundleDocumentTypes 只有 FLAC。

## 改动

### CFBundleDocumentTypes
新增 7 个条目（FLAC 已有），引用系统 UTI 或已导入的 UTI：

- FLAC: org.xiph.flac (UTImported)
- MP3: public.mp3 (系统)
- WAV: com.microsoft.waveform-audio (系统)
- AIFF: public.aiff-audio (系统)
- M4A: public.m4a-audio (系统)
- AAC: public.aac-audio (系统)
- OGG: org.xiph.ogg (UTImported)
- Opus: org.xiph.opus (UTImported)

### UTImportedTypeDeclarations
新增 org.xiph.ogg 和 org.xiph.opus 的声明（flac 已有）。

### 关于 ALAC
ALAC 是 codec，不是独立容器格式，使用 .m4a 扩展名，与 M4A 共用 public.m4a-audio，无需单独声明。

## 验收
- Finder 打开方式、拖拽关联覆盖全部 9 种格式
- GUI 文案（FLAC/MP3/WAV/AIFF/M4A/AAC/OGG/Opus）与系统入口一致
