### PR TITLE
refactor: centralize supported audio format list (SupportedAudioFormat)

### DIFF
--- a/GUI/App/TrackSplitterApp.swift
+++ b/GUI/App/TrackSplitterApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - AppDelegate
 @objc(AppDelegate)

--- a/GUI/App/TrackSplitterApp.swift
+++ b/GUI/App/TrackSplitterApp.swift
@@ -90,16 +90,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [
-            .init(filenameExtension: "flac") ?? .audio,
-            .init(filenameExtension: "mp3") ?? .audio,
-            .init(filenameExtension: "wav") ?? .audio,
-            .init(filenameExtension: "aiff") ?? .audio,
-            .init(filenameExtension: "m4a") ?? .audio,
-            .init(filenameExtension: "aac") ?? .audio,
-            .init(filenameExtension: "ogg") ?? .audio,
-            .init(filenameExtension: "opus") ?? .audio,
-        ]
+        panel.allowedContentTypes = SupportedAudioFormat.utTypes
         panel.title = "选择音频文件"
         panel.message = "选择要拆分的整轨音频文件"
 

--- a/GUI/Models/SupportedAudioFormats.swift
+++ b/GUI/Models/SupportedAudioFormats.swift
@@ -1,0 +1,18 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Supported audio file extensions for input validation and system integration.
+/// Single source of truth — all GUI code paths (drag/drop, file panel, engine load)
+/// reference this constant to stay in sync.
+enum SupportedAudioFormat {
+    /// All supported input file extensions (lowercase, no dot).
+    static let extensions: Set<String> = [
+        "flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"
+    ]
+
+    /// Corresponding `UTType` values for file panels and document type declarations.
+    /// Returns `.audio` as fallback for any extension not recognized by the system.
+    static var utTypes: [UTType] {
+        extensions.map { UTType(filenameExtension: $0) ?? .audio }
+    }
+}

--- a/GUI/Models/SupportedAudioFormats.swift
+++ b/GUI/Models/SupportedAudioFormats.swift
@@ -5,8 +5,8 @@ import UniformTypeIdentifiers
 /// Single source of truth — all GUI code paths (drag/drop, file panel, engine load)
 /// reference this constant to stay in sync.
 enum SupportedAudioFormat {
-    /// All supported input file extensions (lowercase, no dot).
-    static let extensions: Set<String> = [
+    /// All supported input file extensions (lowercase, no dot), in canonical order.
+    static let extensions: [String] = [
         "flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"
     ]
 

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -119,8 +119,7 @@ else:
     func load(audioURL: URL) {
         log("load() called: \(audioURL.path)")
 
-        let supported: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
-        guard supported.contains(audioURL.pathExtension.lowercased()) else {
+        guard SupportedAudioFormat.extensions.contains(audioURL.pathExtension.lowercased()) else {
             log("FAIL: unsupported format")
             setError("不支持的文件格式。支持：FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus")
             return

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -217,9 +217,7 @@ final class DropZoneVisualView: NSView {
         return true
     }
 
-    private static let _supportedExtensions: Set<String> = [
-        "flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"
-    ]
+    private static let _supportedExtensions = SupportedAudioFormat.extensions
 
     private func hasFlacFile(_ info: NSDraggingInfo) -> Bool {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else { return false }

--- a/GUI/Views/DropZoneView.swift
+++ b/GUI/Views/DropZoneView.swift
@@ -128,7 +128,6 @@ class DropZoneNSView: NSView {
         guard let urls = info.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
             return false
         }
-        let exts = urls.map { $0.pathExtension.lowercased() }
         return urls.contains { Self.supportedExtensions.contains($0.pathExtension.lowercased()) }
     }
 

--- a/GUI/Views/DropZoneView.swift
+++ b/GUI/Views/DropZoneView.swift
@@ -26,21 +26,12 @@ class DropZoneNSView: NSView {
         didSet { needsDisplay = true }
     }
 
-    /// 支持的音频格式列表。
-    private static let supportedExtensions: Set<String> = ["flac", "mp3", "wav", "aiff", "alac", "m4a", "aac", "ogg", "opus"]
+    /// 支持的音频格式列表（来自 SupportedAudioFormat）。
+    private static let supportedExtensions = SupportedAudioFormat.extensions
 
-    /// 支持的 UTType 列表。
+    /// 支持的 UTType 列表（来自 SupportedAudioFormat）。
     private static var supportedTypes: [UTType] {
-        [
-            UTType(filenameExtension: "flac") ?? .data,
-            UTType(filenameExtension: "mp3") ?? .data,
-            UTType(filenameExtension: "wav") ?? .data,
-            UTType(filenameExtension: "aiff") ?? .data,
-            UTType(filenameExtension: "m4a") ?? .data,
-            UTType(filenameExtension: "aac") ?? .data,
-            UTType(filenameExtension: "ogg") ?? .data,
-            UTType(filenameExtension: "opus") ?? .data,
-        ]
+        SupportedAudioFormat.utTypes
     }
 
     override init(frame frameRect: NSRect) {

--- a/GUI/project.yml
+++ b/GUI/project.yml
@@ -21,6 +21,8 @@ targets:
         type: group
       - path: ViewModels
         type: group
+      - path: Models
+        type: group
       - path: ../Library
         type: group
         name: TrackSplitterLib

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
                 "GUI/Views/TrackListView.swift",
                 "GUI/Views/ProcessingView.swift",
                 "GUI/ViewModels/SplitterViewModel.swift",
+                "GUI/Models/SupportedAudioFormats.swift",
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## 背景
格式列表在 4 处重复定义，维护成本高且容易漂移：
- SplitterViewModel.swift: supported (Set)
- DropZoneView.swift: supportedExtensions (Set) + supportedTypes ([UTType])
- ContentView.swift: _supportedExtensions (Set)
- TrackSplitterApp.swift: 9 行 UTType 硬编码

## 改动
新增 GUI/Models/SupportedAudioFormats.swift，定义 SupportedAudioFormat enum：
- extensions: Set<String> — 9 个支持的扩展名（lowercase，无点）
- utTypes: [UTType] — 对应的 UTType 数组，不识别时 fallback 到 .audio

4 处引用全部替换为 SupportedAudioFormat.extensions 或 SupportedAudioFormat.utTypes。

Package.swift 和 GUI/project.yml 的 sources 列表均已更新以包含新文件。

## 验收
- swift build 成功，无新增 error
- 格式验证逻辑（load / drag&drop / file panel）全部走同一个常量
- 未来新增格式只需改一处 SupportedAudioFormats.swift
