### PR TITLE
test #17: add automated test suite for CueParser and MetadataEmbedder

### DIFF
--- a/Library/CueParser.swift
+++ b/Library/CueParser.swift
@@ -94,7 +94,11 @@ public func parseCue(at url: URL) throws -> (tracks: [CueTrack], albumTitle: Str
         let line = raw.trimmingCharacters(in: .whitespaces)
 
         if let cap = match(line: line, pattern: #"PERFORMER "([^"]+)""#) {
-            performer = cap
+            // Only update performer at album level; track-level PERFORMER is valid CUE
+            // but we return a single performer field (album level) for now.
+            if curIdx == 0 {
+                performer = cap
+            }
         }
         else if let cap = match(line: line, pattern: #"TITLE "([^"]+)""#) {
             if curIdx > 0 {

--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -31,6 +31,39 @@ public actor MetadataEmbedder {
 
         public var isFullySuccessful: Bool { failed == 0 }
         public var isPartiallySuccessful: Bool { succeeded > 0 && failed > 0 }
+
+        public init(total: Int, succeeded: Int, failed: Int, failures: [String], coverWasSkipped: Bool) {
+            self.total = total
+            self.succeeded = succeeded
+            self.failed = failed
+            self.failures = failures
+            self.coverWasSkipped = coverWasSkipped
+        }
+    }
+
+    /// Parses the stdout lines emitted by embed_metadata.py.
+    /// Exposed for unit testing — call this directly instead of duplicating the logic.
+    static func parseOutput(_ stdout: String) -> (succeeded: Int, failed: Int, failures: [String], coverWasSkipped: Bool) {
+        var succeeded = 0
+        var failed = 0
+        var failures: [String] = []
+        var coverWasSkipped = false
+
+        for line in stdout.components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
+            if line.hasPrefix("DONE: ") {
+                succeeded += 1
+            } else if line.hasPrefix("SKIP: ") {
+                succeeded += 1
+                if line.contains("cover art skipped") {
+                    coverWasSkipped = true
+                }
+            } else if line.hasPrefix("ERROR: ") {
+                failed += 1
+                failures.append(String(line.dropFirst(7)))
+            }
+        }
+
+        return (succeeded, failed, failures, coverWasSkipped)
     }
 
     private let pythonPath: String
@@ -120,33 +153,25 @@ public actor MetadataEmbedder {
 
         let (stdout, stderr, rc) = try await runScript(jsonFile: tempFile)
 
-        // Parse per-file results from stdout
-        var succeeded = 0
-        var failed = 0
-        var failures: [String] = []
-        var coverWasSkipped = false
+        let parsed = Self.parseOutput(stdout)
 
-        for line in stdout.components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
-            if line.hasPrefix("DONE: ") {
-                succeeded += 1
-            } else if line.hasPrefix("SKIP: ") {
-                succeeded += 1
-                if line.contains("cover art skipped") {
-                    coverWasSkipped = true
-                }
-            } else if line.hasPrefix("ERROR: ") {
-                failed += 1
-                failures.append(String(line.dropFirst(7)))
-            }
+        if rc != 0 && parsed.succeeded == 0 && parsed.failed == 0 {
+            return EmbedResult(
+                total: files.count,
+                succeeded: 0,
+                failed: files.count,
+                failures: ["脚本执行失败（RC=\(rc)）：\(stderr.prefix(100))"],
+                coverWasSkipped: parsed.coverWasSkipped
+            )
         }
 
-        if rc != 0 && succeeded == 0 && failed == 0 {
-            failed = files.count
-            failures = ["脚本执行失败（RC=\(rc)）：\(stderr.prefix(100))"]
-        }
-
-        return EmbedResult(total: files.count, succeeded: succeeded, failed: failed,
-                           failures: failures, coverWasSkipped: coverWasSkipped)
+        return EmbedResult(
+            total: files.count,
+            succeeded: parsed.succeeded,
+            failed: parsed.failed,
+            failures: parsed.failures,
+            coverWasSkipped: parsed.coverWasSkipped
+        )
     }
 
     private func runScript(jsonFile: URL) async throws -> (stdout: String, stderr: String, rc: Int32) {

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,11 @@ let package = Package(
             name: "TrackSplitterTests",
             dependencies: ["TrackSplitterLib"],
             path: "Tests",
-            sources: ["AudioSplitterTests.swift"]
+            sources: [
+                "AudioSplitterTests.swift",
+                "CueParserTests.swift",
+                "MetadataEmbedderResultTests.swift",
+            ]
         )
     ]
 )

--- a/Tests/CueParserTests.swift
+++ b/Tests/CueParserTests.swift
@@ -1,0 +1,291 @@
+import Foundation
+@testable import TrackSplitterLib
+import XCTest
+
+/// Tests for CueParser: CUE sheet parsing, string similarity, and findCue fallback logic.
+final class CueParserTests: XCTestCase {
+
+    // MARK: - stringSimilarity
+
+    func testStringSimilarity_identical() {
+        XCTAssertEqual(stringSimilarity("track 1", "track 1"), 1.0)
+    }
+
+    func testStringSimilarity_empty() {
+        XCTAssertEqual(stringSimilarity("", ""), 1.0)
+        XCTAssertEqual(stringSimilarity("abc", ""), 0.0)
+        XCTAssertEqual(stringSimilarity("", "abc"), 0.0)
+    }
+
+    func testStringSimilarity_substitution() {
+        // "track 1" vs "track 2" — one char diff out of 7
+        let ratio = stringSimilarity("track 1", "track 2")
+        XCTAssertGreaterThan(ratio, 0.8)
+        XCTAssertLessThan(ratio, 1.0)
+    }
+
+    func testStringSimilarity_deletion() {
+        let ratio = stringSimilarity("track one", "track on")
+        XCTAssertGreaterThan(ratio, 0.8)
+    }
+
+    func testStringSimilarity_chinese() {
+        // Chinese chars differ significantly from ASCII
+        let ratio = stringSimilarity("整轨音频", "整軌音頻")
+        XCTAssertGreaterThanOrEqual(ratio, 0.5)
+    }
+
+    // MARK: - parseCue: basic structure
+
+    func testParseCue_singleTrack() throws {
+        let cue = """
+        TITLE "Album Title"
+        PERFORMER "Album Artist"
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track One"
+            PERFORMER "Track Artist"
+            INDEX 01 00:00:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.albumTitle, "Album Title")
+        XCTAssertEqual(result.performer, "Album Artist")
+        XCTAssertEqual(result.tracks.count, 1)
+        XCTAssertEqual(result.tracks[0].index, 1)
+        XCTAssertEqual(result.tracks[0].title, "Track One")
+        XCTAssertEqual(result.tracks[0].startSeconds, 0.0, accuracy: 0.01)
+        XCTAssertEqual(result.file?.path, "audio.flac")
+    }
+
+    func testParseCue_multipleTracks() throws {
+        let cue = """
+        TITLE "Album Title"
+        PERFORMER "Album Artist"
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track One"
+            INDEX 01 00:00:00
+          TRACK 02 AUDIO
+            TITLE "Track Two"
+            INDEX 01 03:00:00
+          TRACK 03 AUDIO
+            TITLE "Track Three"
+            INDEX 01 07:30:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.tracks.count, 3)
+        XCTAssertEqual(result.tracks[0].title, "Track One")
+        XCTAssertEqual(result.tracks[1].title, "Track Two")
+        XCTAssertEqual(result.tracks[2].title, "Track Three")
+        // 3 min = 180 sec
+        XCTAssertEqual(result.tracks[1].startSeconds, 180.0, accuracy: 0.01)
+        // 7:30 = 7*60+30 = 450 sec
+        XCTAssertEqual(result.tracks[2].startSeconds, 450.0, accuracy: 0.01)
+    }
+
+    // MARK: - parseCue: timestamps (including frames)
+
+    func testParseCue_timestampWithFrames() throws {
+        // INDEX 01 01:02:50 → 1*60 + 2 + 50/75 = 62.67s
+        let cue = """
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track"
+            INDEX 01 01:02:50
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.tracks[0].startSeconds, 62.0 + 50.0/75.0, accuracy: 0.01)
+    }
+
+    func testParseCue_timestampNoFrames() throws {
+        // Some CUE writers emit INDEX 01 00:00:00 (no frames, always 00)
+        let cue = """
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track"
+            INDEX 01 00:00:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.tracks[0].startSeconds, 0.0, accuracy: 0.01)
+    }
+
+    // MARK: - parseCue: REM fields
+
+    func testParseCue_remFields() throws {
+        let cue = """
+        REM DATE "2024"
+        REM GENRE "Classical"
+        REM COMMENT "Live recording"
+        REM COMPOSER "Beethoven"
+        REM DISCNUMBER "1/2"
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Symphony No.5"
+            INDEX 01 00:00:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.rem.date, "2024")
+        XCTAssertEqual(result.rem.genre, "Classical")
+        XCTAssertEqual(result.rem.comment, "Live recording")
+        XCTAssertEqual(result.rem.composer, "Beethoven")
+        XCTAssertEqual(result.rem.discNumber, "1/2")
+    }
+
+    // MARK: - parseCue: Chinese encoding (iconv fallback)
+
+    func testParseCue_utf8() throws {
+        let cue = "FILE \"测试音频.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"测试曲目\"\n    INDEX 01 00:00:00\n"
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.tracks[0].title, "测试曲目")
+    }
+
+    // MARK: - parseCue: edge cases
+
+    func testParseCue_missingTrackTitle() throws {
+        // Track with no TITLE field — title should be empty string
+        let cue = """
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            INDEX 01 00:00:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.tracks[0].title, "")
+    }
+
+    func testParseCue_performerOnlyOnAlbumLevel() throws {
+        // PERFORMER before any TRACK = album performer; per-track performer not always present
+        let cue = """
+        PERFORMER "Album Artist"
+        FILE "audio.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track One"
+            INDEX 01 00:00:00
+          TRACK 02 AUDIO
+            TITLE "Track Two"
+            INDEX 01 03:00:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.performer, "Album Artist")
+        XCTAssertEqual(result.tracks.count, 2)
+    }
+
+    func testParseCue_filePathWithSpaces() throws {
+        let cue = """
+        FILE "my audio file.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track"
+            INDEX 01 00:00:00
+        """
+        let url = writeCue(cue)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = try parseCue(at: url)
+        XCTAssertEqual(result.file?.path, "my audio file.flac")
+        XCTAssertEqual(result.file?.resolvedURL.lastPathComponent, "my audio file.flac")
+    }
+
+    // MARK: - findCue: exact match
+
+    func testFindCue_exactMatch() throws {
+        let dir = tempDir()
+        let audioURL = dir.appendingPathComponent("test.flac")
+        let cueURL = dir.appendingPathComponent("test.cue")
+        FileManager.default.createFile(atPath: audioURL.path, contents: nil)
+        FileManager.default.createFile(atPath: cueURL.path, contents: nil)
+
+        let result = findCue(for: audioURL)
+        XCTAssertEqual(result, cueURL)
+    }
+
+    func testFindCue_exactMatchOnCaseInsensitiveFS() throws {
+        // APFS is case-insensitive: findCue tries ["cue","CUE","Cue"] in order and
+        // FileManager.fileExists is case-insensitive, so any case matches.
+        let dir = tempDir()
+        let audioURL = dir.appendingPathComponent("test.flac")
+        let cueURL = dir.appendingPathComponent("test.cue")
+        FileManager.default.createFile(atPath: audioURL.path, contents: nil)
+        FileManager.default.createFile(atPath: cueURL.path, contents: nil)
+
+        let result = findCue(for: audioURL)
+        XCTAssertEqual(result, cueURL)
+    }
+
+    // MARK: - findCue: no match
+
+    func testFindCue_noMatchBelowThreshold() throws {
+        let dir = tempDir()
+        let audioURL = dir.appendingPathComponent("completelydifferent.flac")
+        let cueURL = dir.appendingPathComponent("xxx.cue")
+        FileManager.default.createFile(atPath: audioURL.path, contents: nil)
+        // CUE references "xxx.flac" which is very different from "completelydifferent.flac"
+        try """
+        FILE "xxx.flac" WAVE
+          TRACK 01 AUDIO
+            TITLE "X"
+            INDEX 01 00:00:00
+        """.write(to: cueURL, atomically: true, encoding: .utf8)
+
+        let result = findCue(for: audioURL)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - findCue: fuzzy fallback
+
+    func testFindCue_fuzzyMatchAbove80Percent() throws {
+        let dir = tempDir()
+        let audioURL = dir.appendingPathComponent("整轨音频文件.flac")
+        FileManager.default.createFile(atPath: audioURL.path, contents: nil)
+
+        // CUE references same base name (different extension) — should be high similarity
+        let cueURL = dir.appendingPathComponent("整轨音频文件.cue")
+        try """
+        FILE "整轨音频文件.wav" WAVE
+          TRACK 01 AUDIO
+            TITLE "Track"
+            INDEX 01 00:00:00
+        """.write(to: cueURL, atomically: true, encoding: .utf8)
+
+        let result = findCue(for: audioURL)
+        XCTAssertEqual(result, cueURL)
+    }
+
+    // MARK: - Helpers
+
+    private func writeCue(_ content: String) -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("test.cue")
+        try! content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/Tests/MetadataEmbedderResultTests.swift
+++ b/Tests/MetadataEmbedderResultTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+@testable import TrackSplitterLib
+import XCTest
+
+/// Tests for MetadataEmbedder stdout parsing and EmbedResult construction.
+/// Calls the production `MetadataEmbedder.parseOutput()` directly to ensure
+/// tests exercise the actual production code path.
+final class MetadataEmbedderResultTests: XCTestCase {
+
+    // MARK: - EmbedResult computed properties
+
+    func testFullySuccessful_allSucceeded() {
+        let result = MetadataEmbedder.EmbedResult(
+            total: 3, succeeded: 3, failed: 0, failures: [], coverWasSkipped: false
+        )
+        XCTAssertTrue(result.isFullySuccessful)
+        XCTAssertFalse(result.isPartiallySuccessful)
+    }
+
+    func testFullySuccessful_allSucceededWithSkipped() {
+        let result = MetadataEmbedder.EmbedResult(
+            total: 3, succeeded: 3, failed: 0, failures: [], coverWasSkipped: true
+        )
+        XCTAssertTrue(result.isFullySuccessful)
+        XCTAssertFalse(result.isPartiallySuccessful)
+        XCTAssertTrue(result.coverWasSkipped)
+    }
+
+    func testPartiallySuccessful() {
+        let result = MetadataEmbedder.EmbedResult(
+            total: 3, succeeded: 2, failed: 1, failures: ["file2.flac: encoding error"], coverWasSkipped: false
+        )
+        XCTAssertFalse(result.isFullySuccessful)
+        XCTAssertTrue(result.isPartiallySuccessful)
+    }
+
+    func testAllFailed() {
+        let result = MetadataEmbedder.EmbedResult(
+            total: 3, succeeded: 0, failed: 3, failures: ["f1.flac", "f2.flac", "f3.flac"], coverWasSkipped: false
+        )
+        XCTAssertFalse(result.isFullySuccessful)
+        XCTAssertFalse(result.isPartiallySuccessful)
+        XCTAssertEqual(result.failed, 3)
+    }
+
+    func testZeroTotals() {
+        // With total=0 and no failures, isFullySuccessful is true (failed==0).
+        let result = MetadataEmbedder.EmbedResult(
+            total: 0, succeeded: 0, failed: 0, failures: [], coverWasSkipped: false
+        )
+        XCTAssertTrue(result.isFullySuccessful)
+        XCTAssertFalse(result.isPartiallySuccessful)
+    }
+
+    // MARK: - Production parseOutput() — directly tests production code
+
+    func testParseOutput_allDONE() {
+        let stdout = "DONE: file1.flac\nDONE: file2.flac\n"
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        XCTAssertEqual(parsed.succeeded, 2)
+        XCTAssertEqual(parsed.failed, 0)
+        XCTAssertTrue(parsed.failures.isEmpty)
+        XCTAssertFalse(parsed.coverWasSkipped)
+    }
+
+    func testParseOutput_mixedDONESKIPERROR() {
+        let stdout = """
+        DONE: file1.flac
+        SKIP: file2.wav (cover art skipped)
+        ERROR: file3.mp3 invalid tag
+        """
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        XCTAssertEqual(parsed.succeeded, 2)
+        XCTAssertEqual(parsed.failed, 1)
+        XCTAssertEqual(parsed.failures, ["file3.mp3 invalid tag"])
+        XCTAssertTrue(parsed.coverWasSkipped)
+    }
+
+    func testParseOutput_emptyLinesIgnored() {
+        let stdout = "DONE: file1.flac\n\nDONE: file2.flac\n  \n"
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        XCTAssertEqual(parsed.succeeded, 2)
+        XCTAssertEqual(parsed.failed, 0)
+    }
+
+    func testParseOutput_noMatch() {
+        let stdout = "something went wrong\nrandom output"
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        XCTAssertEqual(parsed.succeeded, 0)
+        XCTAssertEqual(parsed.failed, 0)
+        XCTAssertTrue(parsed.failures.isEmpty)
+    }
+
+    func testParseOutput_coverWasSkippedOnly() {
+        let stdout = "SKIP: track.wav (unsupported format, cover art skipped)"
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        XCTAssertEqual(parsed.succeeded, 1)
+        XCTAssertTrue(parsed.coverWasSkipped)
+    }
+
+    func testParseOutput_multipleErrors() {
+        let stdout = """
+        ERROR: a.flac: permission denied
+        ERROR: b.flac: io error
+        DONE: c.flac
+        """
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        XCTAssertEqual(parsed.succeeded, 1)
+        XCTAssertEqual(parsed.failed, 2)
+        XCTAssertEqual(parsed.failures, ["a.flac: permission denied", "b.flac: io error"])
+    }
+
+    // MARK: - End-to-end EmbedResult via parseOutput()
+
+    func testEmbedResult_roundTripFullySuccessful() {
+        let stdout = "DONE: a.flac\nDONE: b.flac\nDONE: c.flac\n"
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let result = MetadataEmbedder.EmbedResult(
+            total: 3,
+            succeeded: parsed.succeeded,
+            failed: parsed.failed,
+            failures: parsed.failures,
+            coverWasSkipped: parsed.coverWasSkipped
+        )
+        XCTAssertTrue(result.isFullySuccessful)
+        XCTAssertEqual(result.succeeded, 3)
+        XCTAssertEqual(result.failed, 0)
+    }
+
+    func testEmbedResult_roundTripPartial() {
+        let stdout = """
+        DONE: good.flac
+        ERROR: bad.flac: permission denied
+        """
+        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let result = MetadataEmbedder.EmbedResult(
+            total: 2,
+            succeeded: parsed.succeeded,
+            failed: parsed.failed,
+            failures: parsed.failures,
+            coverWasSkipped: parsed.coverWasSkipped
+        )
+        XCTAssertTrue(result.isPartiallySuccessful)
+        XCTAssertEqual(result.failures, ["bad.flac: permission denied"])
+    }
+}


### PR DESCRIPTION
## 背景
issue #17: 项目缺乏自动化测试，swift test 报告 0 tests。

## 改动
新增两个测试文件 + 提取 MetadataEmbedder stdout 解析为 production 函数：

### Tests/CueParserTests.swift (18 tests)
- stringSimilarity: 相同/空字符串/单字符替换/删除/中文相似度
- parseCue: 单轨/多轨/帧级时间戳/REM字段/中文UTF-8/缺标题/Album performer/含空格路径
- findCue: 精确匹配(APFS大小写不敏感)/模糊匹配80%/60%阈值以下返回nil

### Tests/MetadataEmbedderResultTests.swift (13 tests)
- EmbedResult.computed properties: isFullySuccessful / isPartiallySuccessful（全成功/部分成功/全失败/零总量）
- **直接调用 production `MetadataEmbedder.parseOutput()`**（不再是测试内复制的解析逻辑）
- Round-trip: stdout解析 → EmbedResult → computed properties

### MetadataEmbedder.swift 重构
- `EmbedResult` 新增 public init（供测试构造）
- 新增 `static MetadataEmbedder.parseOutput(_ stdout: String)` — production 代码，`embedBatch()` 和测试共同调用
- 测试现在真正验证 production 解析逻辑，而非镜像副本

### 附带修复
CueParser.swift: PERFORMER解析增加 curIdx==0 保护，避免track级PERFORMER覆盖album级PERFORMER。

### 验收
- swift test: 33 tests, 0 failures
- AudioSplitterTests(2) + CueParserTests(18) + MetadataEmbedderResultTests(13) = 33
