### PR TITLE
fix issue #23: extend hygiene coverage to *.orig and *~ editor backups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Check repository hygiene
         run: |
           echo "=== Checking for prohibited files ==="
-          # Check for .bak files
-          BAK_FILES=$(find . -name "*.bak" -not -path "./.git/*")
-          if [ -n "$BAK_FILES" ]; then
-            echo "ERROR: .bak files found:"
-            echo "$BAK_FILES"
+          # Check for .bak and .orig files
+          BACKUP_FILES=$(find . \( -name "*.bak" -o -name "*.orig" \) -not -path "./.git/*")
+          if [ -n "$BACKUP_FILES" ]; then
+            echo "ERROR: backup files found:"
+            echo "$BACKUP_FILES"
             exit 1
           fi
 
@@ -30,6 +30,14 @@ jobs:
           if [ -n "$DS_STORE" ]; then
             echo "ERROR: .DS_Store files found:"
             echo "$DS_STORE"
+            exit 1
+          fi
+
+          # Check for editor auto-backup files (e.g. vi ~ backups)
+          EDITOR_BACKUPS=$(find . -name "*~" -not -path "./.git/*")
+          if [ -n "$EDITOR_BACKUPS" ]; then
+            echo "ERROR: editor auto-backup files found:"
+            echo "$EDITOR_BACKUPS"
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 *.icns
 *.iconset/
 GUI/project.yml
+
+# Editor and OS temporary files
+*.orig          # git merge conflict resolution backups
+*~              # vi/macOS TextEdit and other editor auto-backups


### PR DESCRIPTION
## 改动摘要

### 问题
Issue #23 要求清理误提交的备份/临时文件，并增加仓库卫生检查。

### 现状确认
- 主分支当前**已无** `.bak` / `.orig` / `.swp` / `.swo` / `__pycache__` 文件（issue #30 的 CI hygiene 检查已在维护）
- `.gitignore` 已覆盖 `.bak` / `.DS_Store` / `*.swp` / `*.swo` / `__pycache__` / `*.pyc`
- CI hygiene 检查已覆盖以上同类模式

### 本次补充（预防性）
| 文件 | 补充内容 |
|------|---------|
| `.gitignore` | `*.orig`（git merge 冲突备份）+ `*~`（vi/编辑器自动备份）|
| `.github/workflows/ci.yml` | CI 中同步新增 `*.orig` 和 `*~` 的检查 |

### 验收标准对应
- ✅ 主分支不再包含备份/临时文件（已确认，当前为空）
- ✅ `.gitignore` 覆盖常见临时文件模式（本次补充 `*.orig` / `*~`）
- ✅ CI 能阻止此类文件再次提交（本次补充）

`swift test` → 59 tests, 0 failures
