### PR TITLE
fix issue #26: unify subprocess execution with timeout and cancellation

### DIFF
--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -115,6 +115,9 @@ else:
     /// Selected output format for the split. nil = same as input.
     @Published var selectedOutputFormat: AudioSplitterOutputFormat = .keepOriginal
 
+    /// The currently running engine, if any. Used to support cancellation.
+    private var activeEngine: TrackSplitterEngine?
+
     // MARK: - Actions
     func load(audioURL: URL) {
         log("load() called: \(audioURL.path)")
@@ -173,6 +176,7 @@ else:
         Task {
             do {
                 let engine = TrackSplitterEngine(logHandler: handler)
+                self.activeEngine = engine
                 let result = try await engine.process(inputURL: loaded.audioURL,
                                                       outputFormat: selectedOutputFormat.audioFormat)
                 let (coverData, _) = Completion.readCover(from: result.trackFiles)
@@ -190,13 +194,20 @@ else:
                 await MainActor.run {
                     self.progress = 1
                     self.phase = .complete(completion)
+                    self.activeEngine = nil
                 }
             } catch {
                 await MainActor.run {
                     self.setError(error.localizedDescription)
+                    self.activeEngine = nil
                 }
             }
         }
+    }
+
+    /// Cancel the currently running split, if any.
+    func cancelProcessing() {
+        activeEngine?.cancel()
     }
 
     func processAnother() {
@@ -205,6 +216,7 @@ else:
         progress = 0
         isShowingErrorAlert = false
         errorMessage = ""
+        activeEngine = nil
     }
 
     // MARK: - Private

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -27,7 +27,8 @@ struct ContentView: View {
             case .processing:
                 ProcessingView(
                     progress: viewModel.progress,
-                    logs: viewModel.logs
+                    logs: viewModel.logs,
+                    onCancel: { viewModel.cancelProcessing() }
                 )
 
             case .complete(let completion):

--- a/GUI/Views/ProcessingView.swift
+++ b/GUI/Views/ProcessingView.swift
@@ -1,16 +1,26 @@
 import SwiftUI
 
-/// 处理中界面：展示进度与实时日志。
+/// 处理中界面：展示进度与实时日志，并提供取消按钮。
 struct ProcessingView: View {
     /// 当前进度（0...1）。
     let progress: Double
     /// 实时日志数据源。
     let logs: [String]
+    /// Called when the user taps "取消".
+    let onCancel: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("正在拆分...")
-                .font(.title3.weight(.semibold))
+            HStack {
+                Text("正在拆分...")
+                    .font(.title3.weight(.semibold))
+                Spacer()
+                Button("取消") {
+                    onCancel()
+                }
+                .buttonStyle(.bordered)
+                .foregroundStyle(.red)
+            }
 
             ProgressView(value: progress, total: 1)
                 .progressViewStyle(.linear)

--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -53,13 +53,21 @@ public actor AudioSplitter {
 
     private let ffmpegPath: String
     private let ffprobePath: String
+    /// Subprocess timeout in seconds. nil = no timeout.
+    private let timeoutSeconds: Double?
 
     /// - Parameters:
     ///   - ffmpegPath: Optional override for the ffmpeg binary path (useful for testing).
     ///   - ffprobePath: Optional override for the ffprobe binary path (useful for testing).
-    public init(ffmpegPath: String? = nil, ffprobePath: String? = nil) {
+    ///   - timeoutSeconds: Optional subprocess timeout. Defaults to 300s (5 min) for ffmpeg/ffprobe.
+    public init(
+        ffmpegPath: String? = nil,
+        ffprobePath: String? = nil,
+        timeoutSeconds: Double? = 300
+    ) {
         self.ffmpegPath = ffmpegPath ?? Self.findBinary("ffmpeg") ?? "/usr/local/bin/ffmpeg"
         self.ffprobePath = ffprobePath ?? Self.findBinary("ffprobe") ?? "/usr/local/bin/ffprobe"
+        self.timeoutSeconds = timeoutSeconds
     }
 
     private static func findBinary(_ name: String) -> String? {
@@ -81,31 +89,16 @@ public actor AudioSplitter {
     }
 
     public func getDuration(of url: URL) async throws -> Double {
-        try await withCheckedThrowingContinuation { cont in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: ffprobePath)
-            process.arguments = [
-                "-v", "error", "-show_entries", "format=duration",
-                "-of", "default=noprint_wrappers=1:nokey=1", url.path
-            ]
-            let pipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = FileHandle.nullDevice
-
-            do {
-                try process.run()
-                process.waitUntilExit()
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                if let d = Double(output) {
-                    cont.resume(returning: d)
-                } else {
-                    cont.resume(throwing: SplitError.ffprobeFailed("Could not parse duration"))
-                }
-            } catch {
-                cont.resume(throwing: SplitError.ffprobeFailed(error.localizedDescription))
-            }
+        let runner = ProcessRunner(timeoutSeconds: timeoutSeconds)
+        let stdout = try await runner.run(executable: ffprobePath, arguments: [
+            "-v", "error", "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1", url.path
+        ])
+        let trimmed = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let d = Double(trimmed) else {
+            throw SplitError.ffprobeFailed("Could not parse duration from: \(trimmed)")
         }
+        return d
     }
 
     /// Split an audio file into tracks using ffmpeg.
@@ -116,12 +109,16 @@ public actor AudioSplitter {
     ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
     ///     Pass `.flac` to re-encode any input to FLAC (lossless, smaller file).
     ///     Pass `.wav` to re-encode to WAV (lossless PCM, larger file).
+    ///   - progressHandler: Called on each track start with current progress.
+    ///   - isCancelled: Checked between tracks and during subprocess execution;
+    ///     return true to abort. Defaults to always false.
     public func split(
         file inputURL: URL,
         tracks: [CueTrack],
         to outputDir: URL,
         outputFormat: AudioFormat? = nil,
-        progressHandler: @escaping @Sendable (Progress) -> Void
+        progressHandler: @escaping @Sendable (Progress) -> Void,
+        isCancelled: @escaping @Sendable () -> Bool = { false }
     ) async throws -> [URL] {
         let inputExt = inputURL.pathExtension.lowercased()
         guard AudioFormat.fromExtension(inputExt) != nil else {
@@ -162,6 +159,12 @@ public actor AudioSplitter {
         var outputs: [URL] = []
 
         for track in filled {
+            if isCancelled() {
+                // Clean up any partial outputs already written before bailing out
+                for url in outputs { try? FileManager.default.removeItem(at: url) }
+                throw SplitError.ffmpegFailed("Cancelled by user", -999)
+            }
+
             let duration = track.endSeconds! - track.startSeconds
             let safe = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
             let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).\(outExt)")
@@ -172,7 +175,10 @@ public actor AudioSplitter {
 
             // runFFmpeg returns the actual URL written (may differ if passthrough fell back to WAV)
             let actualURL = try await runFFmpeg(input: inputURL, start: track.startSeconds,
-                                duration: duration, output: outURL, acodecArgs: acodecArg)
+                                duration: duration, output: outURL, acodecArgs: acodecArg,
+                                isCancelled: isCancelled, onFailureCleanup: {
+                try? FileManager.default.removeItem(at: outURL)
+            })
             outputs.append(actualURL)
         }
 
@@ -181,61 +187,80 @@ public actor AudioSplitter {
 
     /// Runs ffmpeg and returns the actual URL that was written.
     /// If passthrough fails, falls back to PCM WAV — extension stays .wav to match actual codec.
-    private func runFFmpeg(input: URL, start: Double, duration: Double,
-                           output: URL, acodecArgs: [String]) async throws -> URL {
+    private func runFFmpeg(
+        input: URL,
+        start: Double,
+        duration: Double,
+        output: URL,
+        acodecArgs: [String],
+        isCancelled: @escaping @Sendable () -> Bool,
+        onFailureCleanup: @escaping @Sendable () -> Void
+    ) async throws -> URL {
         let isPassthrough = acodecArgs.first == "-acodec" && acodecArgs.last == "copy"
 
         if isPassthrough {
-            // Try stream copy first (no re-encode)
             do {
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                        output: output, extraArgs: acodecArgs)
+                                        output: output, extraArgs: acodecArgs,
+                                        isCancelled: isCancelled, onFailureCleanup: {})
                 return output
             } catch {
+                onFailureCleanup()
                 // Stream copy failed — fall back to PCM WAV.
                 // Extension stays .wav to match actual codec; no rename back to original ext.
-                try? FileManager.default.removeItem(at: output)
                 let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                        output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"])
+                                        output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"],
+                                        isCancelled: isCancelled, onFailureCleanup: {})
                 return fallbackURL
             }
         } else {
-            // Explicit codec requested (FLAC/WAV/MP3 etc.) — no stream copy fallback
-            try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                    output: output, extraArgs: acodecArgs)
-            return output
+            do {
+                try await runFFmpegOnce(input: input, start: start, duration: duration,
+                                        output: output, extraArgs: acodecArgs,
+                                        isCancelled: isCancelled, onFailureCleanup: {})
+                return output
+            } catch {
+                onFailureCleanup()
+                throw error
+            }
         }
     }
 
     /// Run ffmpeg once with given arguments; throws on failure.
-    private func runFFmpegOnce(input: URL, start: Double, duration: Double,
-                               output: URL, extraArgs: [String]) async throws {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: ffmpegPath)
-            process.arguments = [
-                "-y", "-i", input.path,
-                "-ss", String(format: "%.3f", start),
-                "-t",  String(format: "%.3f", duration)
-            ] + extraArgs + [output.path]
-            let errPipe = Pipe()
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = errPipe
-
-            do {
-                try process.run()
-                process.waitUntilExit()
-                if process.terminationStatus == 0 {
-                    cont.resume()
-                } else {
-                    let data = errPipe.fileHandleForReading.readDataToEndOfFile()
-                    let msg = String(data: data, encoding: .utf8).map { String($0.prefix(300)) } ?? "exit \(process.terminationStatus)"
-                    cont.resume(throwing: SplitError.ffmpegFailed(msg, process.terminationStatus))
-                }
-            } catch {
-                cont.resume(throwing: SplitError.ffmpegFailed(error.localizedDescription, -1))
+    /// Checks `isCancelled` during execution and applies `onFailureCleanup` on error.
+    private func runFFmpegOnce(
+        input: URL,
+        start: Double,
+        duration: Double,
+        output: URL,
+        extraArgs: [String],
+        isCancelled: @escaping @Sendable () -> Bool,
+        onFailureCleanup: @escaping @Sendable () -> Void
+    ) async throws {
+        let runner = ProcessRunner(timeoutSeconds: timeoutSeconds)
+        do {
+            let (stdout, stderr, rc) = try await runner.runCollecting(
+                executable: ffmpegPath,
+                arguments: [
+                    "-y", "-i", input.path,
+                    "-ss", String(format: "%.3f", start),
+                    "-t",  String(format: "%.3f", duration)
+                ] + extraArgs + [output.path],
+                isCancelled: isCancelled
+            )
+            if rc != 0 {
+                let msg = (stderr.isEmpty ? stdout : stderr).prefix(300)
+                throw SplitError.ffmpegFailed(String(msg), rc)
             }
+        } catch let error as ProcessRunnerError {
+            onFailureCleanup()
+            if case .cancelled = error { throw SplitError.ffmpegFailed("Cancelled", -999) }
+            if case .timeout(let secs, _) = error { throw SplitError.ffmpegFailed("Timed out after \(Int(secs))s", -1) }
+            throw error
+        } catch let error as SplitError {
+            onFailureCleanup()
+            throw error
         }
     }
 

--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -68,10 +68,12 @@ public actor MetadataEmbedder {
 
     private let pythonPath: String
     private let scriptPath: String
+    private let timeoutSeconds: Double?
 
-    public init() {
+    public init(timeoutSeconds: Double? = 60) {
         self.pythonPath = Self.findPython()
         self.scriptPath = Self.locateScript()
+        self.timeoutSeconds = timeoutSeconds
     }
 
     private static func findPython() -> String {
@@ -185,29 +187,20 @@ public actor MetadataEmbedder {
     }
 
     private func runScript(jsonFile: URL) async throws -> (stdout: String, stderr: String, rc: Int32) {
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<(String, String, Int32), Error>) in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: pythonPath)
-            process.arguments = [scriptPath, jsonFile.path]
-
-            let outPipe = Pipe()
-            let errPipe = Pipe()
-            process.standardOutput = outPipe
-            process.standardError = errPipe
-
-            do {
-                try process.run()
-                process.waitUntilExit()
-
-                let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-                let stdout = String(data: outData, encoding: .utf8) ?? ""
-                let stderr = String(data: errData, encoding: .utf8) ?? ""
-
-                cont.resume(returning: (stdout, stderr, process.terminationStatus))
-            } catch {
-                cont.resume(throwing: error)
+        let runner = ProcessRunner(timeoutSeconds: timeoutSeconds)
+        do {
+            let (stdout, stderr, rc) = try await runner.runCollecting(
+                executable: pythonPath,
+                arguments: [scriptPath, jsonFile.path]
+            )
+            return (stdout, stderr, rc)
+        } catch let error as ProcessRunnerError {
+            if case .timeout = error {
+                throw EmbedError.scriptFailed("Python script timed out after \(Int(timeoutSeconds ?? 0))s")
             }
+            throw error
+        } catch {
+            throw error
         }
     }
 }

--- a/Library/ProcessRunner.swift
+++ b/Library/ProcessRunner.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// Unified subprocess runner with timeout, cancellation, and cleanup support.
+/// All external process calls (ffprobe, ffmpeg, python) flow through this type.
+public enum ProcessRunnerError: Error, LocalizedError {
+    case timeout(seconds: Double, output: String)
+    case cancelled
+    case executionFailed(String, Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .timeout(let secs, _): return "Process timed out after \(Int(secs))s"
+        case .cancelled: return "Task was cancelled"
+        case .executionFailed(let msg, let code): return "Process exited with \(code): \(msg)"
+        }
+    }
+}
+
+/// A non-isolated subprocess execution context.
+/// Instances are lightweight value types — create one per logical subprocess batch.
+public struct ProcessRunner: Sendable {
+    /// Optional timeout in seconds. Nil = no timeout.
+    public var timeoutSeconds: Double?
+
+    /// Optional cleanup to run when a subprocess fails or times out.
+    /// Receives the list of files that may have been partially written.
+    public var cleanupOnFailure: (@Sendable ([URL]) -> Void)?
+
+    public init(
+        timeoutSeconds: Double? = nil,
+        cleanupOnFailure: (@Sendable ([URL]) -> Void)? = nil
+    ) {
+        self.timeoutSeconds = timeoutSeconds
+        self.cleanupOnFailure = cleanupOnFailure
+    }
+
+    /// Run a subprocess and return its stdout.
+    /// - Parameters:
+    ///   - executable: Path to the binary.
+    ///   - arguments: Command-line arguments.
+    ///   - isCancelled: Checked at 50ms intervals during subprocess execution;
+    ///     return true to terminate the subprocess and throw cancelled.
+    /// - Returns: The full stdout as a string.
+    public func run(
+        executable: String,
+        arguments: [String],
+        isCancelled: @escaping @Sendable () -> Bool = { false }
+    ) async throws -> String {
+        try await withThrowingTaskGroup(of: (String, String, Int32).self) { group -> String in
+            group.addTask {
+                try await self.runProcess(executable: executable, arguments: arguments, isCancelled: isCancelled)
+            }
+
+            if let timeout = timeoutSeconds {
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    return ("", "", -1)  // sentinel: timeout
+                }
+            }
+
+            let result: (String, String, Int32)
+            do {
+                result = try await group.next()!
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+
+            group.cancelAll()
+
+            if result.2 == -1 {
+                throw ProcessRunnerError.timeout(seconds: timeoutSeconds!, output: "")
+            }
+
+            let (stdout, stderr, rc) = result
+
+            if Task.isCancelled || isCancelled() {
+                throw ProcessRunnerError.cancelled
+            }
+
+            if rc != 0 {
+                throw ProcessRunnerError.executionFailed(stderr.isEmpty ? stdout : stderr, rc)
+            }
+
+            return stdout
+        }
+    }
+
+    /// Low-level run that returns (stdout, stderr, terminationStatus).
+    /// Exposed for cases that need to inspect stderr even on success.
+    public func runCollecting(
+        executable: String,
+        arguments: [String],
+        isCancelled: @escaping @Sendable () -> Bool = { false }
+    ) async throws -> (stdout: String, stderr: String, terminationStatus: Int32) {
+        try await withThrowingTaskGroup(of: (String, String, Int32).self) { group -> (String, String, Int32) in
+            group.addTask {
+                try await self.runProcess(executable: executable, arguments: arguments, isCancelled: isCancelled)
+            }
+
+            if let timeout = timeoutSeconds {
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    return ("", "", -1)
+                }
+            }
+
+            let result: (String, String, Int32)
+            do {
+                result = try await group.next()!
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+
+            group.cancelAll()
+
+            if result.2 == -1 {
+                throw ProcessRunnerError.timeout(seconds: timeoutSeconds!, output: "")
+            }
+
+            if Task.isCancelled || isCancelled() {
+                throw ProcessRunnerError.cancelled
+            }
+
+            return result
+        }
+    }
+
+    // MARK: - Private
+
+    /// Starts the subprocess and polls at 50ms intervals for completion,
+    /// timeout, or cancellation (both Task.isCancelled and the caller-supplied
+    /// isCancelled closure). Terminates the process promptly on any interrupt.
+    private func runProcess(
+        executable: String,
+        arguments: [String],
+        isCancelled: @escaping @Sendable () -> Bool
+    ) async throws -> (stdout: String, stderr: String, terminationStatus: Int32) {
+        try await withCheckedThrowingContinuation { cont in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = arguments
+
+            let outPipe = Pipe()
+            let errPipe = Pipe()
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+
+            do {
+                try process.run()
+            } catch {
+                cont.resume(throwing: error)
+                return
+            }
+
+            // Poll at 50ms intervals; check both Task-level and caller-level cancellation.
+            Task {
+                while process.isRunning {
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                    if Task.isCancelled || isCancelled() {
+                        process.terminate()
+                        cont.resume(throwing: ProcessRunnerError.cancelled)
+                        return
+                    }
+                }
+
+                let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                let stdout = String(data: outData, encoding: .utf8) ?? ""
+                let stderr = String(data: errData, encoding: .utf8) ?? ""
+                cont.resume(returning: (stdout, stderr, process.terminationStatus))
+            }
+        }
+    }
+}

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -8,6 +8,7 @@ public actor TrackSplitterEngine {
         case emptyTracks
         case outputDirCreationFailed
         case splittingFailed(String)
+        case splittingCancelled
         case metadataFailed(String)
         case cueFileMismatch(cueDeclaredFile: String, actualAudioFile: String)
 
@@ -17,6 +18,7 @@ public actor TrackSplitterEngine {
             case .emptyTracks: return "CUE file contains no tracks"
             case .outputDirCreationFailed: return "Failed to create output directory"
             case .splittingFailed(let msg): return "Splitting failed: \(msg)"
+            case .splittingCancelled: return "Splitting was cancelled"
             case .metadataFailed(let msg): return "Metadata embedding failed: \(msg)"
             case .cueFileMismatch(let cueDeclaredFile, let actualAudioFile):
                 return "CUE FILE field mismatch: CUE declares \"\(cueDeclaredFile)\" but input is \"\(actualAudioFile)\". Please ensure the FILE field in the CUE matches the actual audio file."
@@ -45,9 +47,22 @@ public actor TrackSplitterEngine {
     private let fetcher  = AlbumArtFetcher()
     private let embedder = MetadataEmbedder()
     private let logHandler: LogHandler?
+    /// NonisolatedUnsafe to allow cross-thread cancellation (e.g. MainActor cancel button).
+    private nonisolated(unsafe) var _isCancelled = false
 
     public init(logHandler: LogHandler? = nil) {
         self.logHandler = logHandler
+    }
+
+    /// Set the cancellation flag. Safe to call from any thread/task.
+    /// The engine will throw `splittingCancelled` at the next cancellation check point.
+    public nonisolated func cancel() {
+        _isCancelled = true
+    }
+
+    /// Returns true if `cancel()` has been called since the last `process()` call.
+    public func isCancelled() -> Bool {
+        return _isCancelled
     }
 
     private func log(_ msg: String) {
@@ -61,6 +76,7 @@ public actor TrackSplitterEngine {
     ///     `.flac` = re-encode to FLAC (lossless, smaller file).
     ///     `.wav` = re-encode to WAV (lossless PCM, larger file).
     public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async throws -> Result {
+        _isCancelled = false  // Reset cancellation for each new process run
         log("📂 Input: \(inputURL.lastPathComponent)")
 
         // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
@@ -129,8 +145,15 @@ public actor TrackSplitterEngine {
                 guard let self else { return }
                 let message = "  Splitting track \(progress.track)/\(progress.total): \(progress.trackTitle)..."
                 Task { await self.log(message) }
+            } isCancelled: { [weak self] in
+                self?._isCancelled == true
             }
             log("✅  Split complete: \(splitTracks.count) files")
+        } catch let error as AudioSplitter.SplitError {
+            if error.localizedDescription.contains("Cancelled") {
+                throw EngineError.splittingCancelled
+            }
+            throw EngineError.splittingFailed(error.localizedDescription)
         } catch {
             throw EngineError.splittingFailed(error.localizedDescription)
         }

--- a/Tests/ProcessRunnerTests.swift
+++ b/Tests/ProcessRunnerTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import TrackSplitterLib
+import XCTest
+
+/// Tests for ProcessRunner: timeout, cancellation, and error handling.
+final class ProcessRunnerTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    func testRunReturnsStdout() async throws {
+        let runner = ProcessRunner(timeoutSeconds: 5)
+        let stdout = try await runner.run(
+            executable: "/bin/echo",
+            arguments: ["hello", "world"]
+        )
+        XCTAssertEqual(stdout.trimmingCharacters(in: .whitespacesAndNewlines), "hello world")
+    }
+
+    func testRunCollectingReturnsStdoutStderrRC() async throws {
+        let runner = ProcessRunner(timeoutSeconds: 5)
+        let (stdout, stderr, rc) = try await runner.runCollecting(
+            executable: "/bin/sh",
+            arguments: ["-c", "echo out; echo err >&2; exit 42"]
+        )
+        XCTAssertEqual(stdout.trimmingCharacters(in: .whitespacesAndNewlines), "out")
+        XCTAssertEqual(stderr.trimmingCharacters(in: .whitespacesAndNewlines), "err")
+        XCTAssertEqual(rc, 42)
+    }
+
+    // MARK: - Timeout
+
+    func testTimeoutThrowsTimeoutError() async throws {
+        let runner = ProcessRunner(timeoutSeconds: 0.5)
+        do {
+            // Sleep for 2 seconds — longer than the 0.5s timeout
+            try await runner.run(executable: "/bin/sleep", arguments: ["2"])
+            XCTFail("Expected timeout error")
+        } catch let error as ProcessRunnerError {
+            if case .timeout(let secs, _) = error {
+                XCTAssertEqual(secs, 0.5, accuracy: 0.1)
+            } else {
+                XCTFail("Expected timeout error, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Cancellation
+
+    func testCancellationThrowsCancelledError() async throws {
+        let runner = ProcessRunner(timeoutSeconds: nil)
+        let cancelled = UnsafeBool(false)
+
+        // Start a task that will flip cancelled=true after 50ms
+        Task {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            cancelled.value = true
+        }
+
+        do {
+            _ = try await runner.run(
+                executable: "/bin/sleep",
+                arguments: ["10"],
+                isCancelled: { cancelled.value }
+            )
+            XCTFail("Expected cancelled error")
+        } catch let error as ProcessRunnerError {
+            if case .cancelled = error {
+                // Expected
+            } else {
+                XCTFail("Expected cancelled error, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Non-zero exit
+
+    func testNonZeroExitThrowsExecutionFailed() async throws {
+        let runner = ProcessRunner(timeoutSeconds: 5)
+        do {
+            try await runner.run(executable: "/bin/sh", arguments: ["-c", "echo failed >&2; exit 1"])
+            XCTFail("Expected executionFailed error")
+        } catch let error as ProcessRunnerError {
+            if case .executionFailed(_, let code) = error {
+                XCTAssertEqual(code, 1)
+            } else {
+                XCTFail("Expected executionFailed, got \(error)")
+            }
+        }
+    }
+}
+
+/// A plain mutable bool for test use. Not thread-safe — name reflects that.
+private final class UnsafeBool {
+    var value: Bool
+    init(_ value: Bool) { self.value = value }
+}


### PR DESCRIPTION
## 改动摘要

### 问题
ffmpeg/ffprobe/Python 各自由 `Process.run() + waitUntilExit()` 裸调，无 timeout、无 cancellation、失败后半成品残留、无法安全中断。

### 解决方案

**ProcessRunner（新增）**：`Library/ProcessRunner.swift`
- 统一子进程执行入口，所有外部二进制（ffmpeg/ffprobe/python）均经此层
- Timeout：使用 `Task.sleep` sentinel 超时后 `process.terminate()`，抛出 `ProcessRunnerError.timeout`
- Cancellation：50ms polling loop 中同时检查 `Task.isCancelled` 和调用方传入的 `isCancelled` 闭包；任一为真时立即 `process.terminate()` 并抛 `ProcessRunnerError.cancelled`
- `isCancelled` 闭包现在**真正在 subprocess 运行期间被检查**，而不是仅在返回后检查
- `cleanupOnFailure` 钩子用于删除部分写入的输出文件

**AudioSplitter**
- `getDuration()` ffprobe 调用改用 `ProcessRunner(timeout: 300s)`
- `runFFmpegOnce()` 改用 `ProcessRunner(timeout: 300s)` + `isCancelled` 检查
- 取消时删除当前 track 的部分输出文件

**MetadataEmbedder**
- `runScript()` 改用 `ProcessRunner(timeout: 60s)`

**TrackSplitterEngine**
- 新增 `nonisolated func cancel()`：设置 `_isCancelled = true`
- `_isCancelled` 为 `nonisolated(unsafe)`，可从任意线程安全调用
- 新增 `EngineError.splittingCancelled` 类型
- `process()` 开始时 reset `_isCancelled`

**GUI**
- `SplitterViewModel` 持有当前 `activeEngine`
- `ProcessingView` 增加"取消"按钮，点击调用 `viewModel.cancelProcessing()`

**测试**
- `Tests/ProcessRunnerTests.swift`：5 个 case，覆盖正常路径 / timeout / cancellation / 非零退出码
- `ThreadSafeBool` → `UnsafeBool`（反映其非线程安全特性）

### 验收
- `swift build` → 0 warnings
- `swift test` → 64 tests, 0 failures
