### PR TITLE
feat: model partial-success as explicit EngineOutcome (#27)

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -52,21 +52,31 @@ struct TrackSplitterCLI {
 
         print("🎧 TrackSplitter v1.0.0\n")
 
-        do {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                Task {
-                    do {
-                        let r = try await engine.process(inputURL: audioURL)
-                        print("\n✅ Done! \(r.trackFiles.count) tracks saved to:")
-                        print("   \(r.outputDirectory.path)")
-                        continuation.resume()
-                    } catch {
-                        print("\n❌ Error: \(error.localizedDescription)")
-                        continuation.resume(throwing: error)
-                    }
+        let outcome = await engine.process(inputURL: audioURL)
+        switch outcome.status {
+        case .success:
+            guard let output = outcome.output else {
+                print("\n❌ Internal error: no output")
+                exit(1)
+            }
+            print("\n✅ Done! \(output.trackFiles.count) tracks saved to:")
+            print("   \(output.outputDirectory.path)")
+        case .partialSuccess:
+            guard let output = outcome.output else {
+                print("\n❌ Internal error: no output")
+                exit(1)
+            }
+            print("\n⚠️  Partial success — \(output.trackFiles.count) audio files saved to:")
+            print("   \(output.outputDirectory.path)")
+            if !output.metadataResult.failures.isEmpty {
+                print("   Metadata failed for \(output.metadataResult.failed) track(s):")
+                for f in output.metadataResult.failures.prefix(5) {
+                    print("     • \(f)")
                 }
             }
-        } catch {
+            print("   Use --keep-partial to retain these files, or delete manually.")
+        case .failure:
+            print("\n❌ \(outcome.summary)")
             exit(1)
         }
     }

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -74,7 +74,6 @@ struct TrackSplitterCLI {
                     print("     • \(f)")
                 }
             }
-            print("   Use --keep-partial to retain these files, or delete manually.")
         case .failure:
             print("\n❌ \(outcome.summary)")
             exit(1)

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -174,33 +174,38 @@ else:
         }
 
         Task {
-            do {
-                let engine = TrackSplitterEngine(logHandler: handler)
-                self.activeEngine = engine
-                let result = try await engine.process(inputURL: loaded.audioURL,
-                                                      outputFormat: selectedOutputFormat.audioFormat)
-                let (coverData, _) = Completion.readCover(from: result.trackFiles)
-                let completion = Completion(
-                    outputDirectory: result.outputDirectory,
-                    trackFiles: result.trackFiles,
-                    albumTitle: result.albumTitle,
-                    performer: result.performer,
-                    coverImageData: coverData,
-                    coverEmbedded: result.coverEmbedded,
-                    metadataSucceededCount: result.metadataResult.succeeded,
-                    metadataFailedCount: result.metadataResult.failed,
-                    metadataFailures: result.metadataResult.failures
-                )
-                await MainActor.run {
-                    self.progress = 1
+            let engine = TrackSplitterEngine(logHandler: handler)
+            self.activeEngine = engine
+            let outcome = await engine.process(inputURL: loaded.audioURL,
+                                               outputFormat: selectedOutputFormat.audioFormat)
+
+            await MainActor.run {
+                self.progress = 1
+                switch outcome.status {
+                case .success, .partialSuccess:
+                    guard let output = outcome.output else {
+                        // Shouldn't happen, but treat as error
+                        self.setError("Internal error: no output available")
+                        self.activeEngine = nil
+                        return
+                    }
+                    let (coverData, _) = Completion.readCover(from: output.trackFiles)
+                    let completion = Completion(
+                        outputDirectory: output.outputDirectory,
+                        trackFiles: output.trackFiles,
+                        albumTitle: output.albumTitle,
+                        performer: output.performer,
+                        coverImageData: coverData,
+                        coverEmbedded: output.coverEmbedded,
+                        metadataSucceededCount: output.metadataResult.succeeded,
+                        metadataFailedCount: output.metadataResult.failed,
+                        metadataFailures: output.metadataResult.failures
+                    )
                     self.phase = .complete(completion)
-                    self.activeEngine = nil
+                case .failure:
+                    self.setError(outcome.summary)
                 }
-            } catch {
-                await MainActor.run {
-                    self.setError(error.localizedDescription)
-                    self.activeEngine = nil
-                }
+                self.activeEngine = nil
             }
         }
     }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -165,11 +165,18 @@ public actor TrackSplitterEngine {
     /// Call this when the caller chooses not to keep a partial-success result.
     public func cleanup() {
         guard let out = _lastOutput else { return }
-        for file in out.trackFiles {
+        Self.cleanup(output: out)
+        _lastOutput = nil
+    }
+
+    /// Delete the given output's track files and output directory.
+    /// Exposed as a static method so callers who already hold an `Output` can clean up
+    /// without going through the engine instance.
+    public static func cleanup(output: Output) {
+        for file in output.trackFiles {
             try? FileManager.default.removeItem(at: file)
         }
-        try? FileManager.default.removeItem(at: out.outputDirectory)
-        _lastOutput = nil
+        try? FileManager.default.removeItem(at: output.outputDirectory)
     }
 
     /// Process an audio file + CUE sheet and produce individual track files with metadata.

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -9,7 +9,6 @@ public actor TrackSplitterEngine {
         case outputDirCreationFailed
         case splittingFailed(String)
         case splittingCancelled
-        case metadataFailed(String)
         case cueFileMismatch(cueDeclaredFile: String, actualAudioFile: String)
 
         public var errorDescription: String? {
@@ -19,14 +18,61 @@ public actor TrackSplitterEngine {
             case .outputDirCreationFailed: return "Failed to create output directory"
             case .splittingFailed(let msg): return "Splitting failed: \(msg)"
             case .splittingCancelled: return "Splitting was cancelled"
-            case .metadataFailed(let msg): return "Metadata embedding failed: \(msg)"
             case .cueFileMismatch(let cueDeclaredFile, let actualAudioFile):
                 return "CUE FILE field mismatch: CUE declares \"\(cueDeclaredFile)\" but input is \"\(actualAudioFile)\". Please ensure the FILE field in the CUE matches the actual audio file."
             }
         }
     }
 
-    public struct Result: Sendable {
+    /// Explicit outcome model for the entire process.
+    /// Distinguishes complete success, partial success (split succeeded but metadata partially/fully failed),
+    /// and complete failure (nothing usable was produced).
+    public enum EngineOutcome: Sendable {
+        public enum Status: String, Sendable {
+            case success          /// Split and metadata all succeeded.
+            case partialSuccess   /// Split succeeded; metadata partially or fully failed; usable files exist on disk.
+            case failure          /// Nothing usable was produced (pre-split failure, or split itself failed).
+        }
+
+        case success(Output)
+        case partialSuccess(Output, metadataFailures: [String])
+        case failure(message: String)
+
+        public var status: Status {
+            switch self {
+            case .success:        return .success
+            case .partialSuccess: return .partialSuccess
+            case .failure:        return .failure
+            }
+        }
+
+        /// The output directory and file list, if any split files exist.
+        public var output: Output? {
+            switch self {
+            case .success(let o):              return o
+            case .partialSuccess(let o, _):     return o
+            case .failure:                     return nil
+            }
+        }
+
+        /// Human-readable summary message.
+        public var summary: String {
+            switch self {
+            case .success(let o):
+                return "成功：\(o.trackFiles.count) 个曲目已输出到 \(o.outputDirectory.lastPathComponent)"
+            case .partialSuccess(let o, let metaFails):
+                let metaMsg = metaFails.isEmpty
+                    ? "元数据写入全部失败"
+                    : "元数据写入失败：\(metaFails.count) 个曲目"
+                return "部分成功：\(o.trackFiles.count) 个音频文件已输出（\(metaMsg)）"
+            case .failure(let msg):
+                return "失败：\(msg)"
+            }
+        }
+    }
+
+    /// The substantive output of a process run — always tied to at least one track file existing.
+    public struct Output: Sendable {
         public let outputDirectory: URL
         public let trackFiles: [URL]
         public let albumTitle: String?
@@ -35,6 +81,50 @@ public actor TrackSplitterEngine {
         public let coverEmbedded: Bool
         /// Per-track metadata embedding result.
         public let metadataResult: MetadataEmbedder.EmbedResult
+
+        public init(outputDirectory: URL, trackFiles: [URL], albumTitle: String?, performer: String?,
+                    coverEmbedded: Bool, metadataResult: MetadataEmbedder.EmbedResult) {
+            self.outputDirectory = outputDirectory
+            self.trackFiles = trackFiles
+            self.albumTitle = albumTitle
+            self.performer = performer
+            self.coverEmbedded = coverEmbedded
+            self.metadataResult = metadataResult
+        }
+    }
+
+    /// Legacy result struct — retained for API compatibility with existing callers.
+    /// Internally `process()` now returns `EngineOutcome`; this is constructed from `outcome.output`.
+    public struct Result: Sendable {
+        public let outputDirectory: URL
+        public let trackFiles: [URL]
+        public let albumTitle: String?
+        public let performer: String?
+        public let coverEmbedded: Bool
+        public let metadataResult: MetadataEmbedder.EmbedResult
+
+        public init(outputDirectory: URL, trackFiles: [URL], albumTitle: String?, performer: String?,
+                    coverEmbedded: Bool, metadataResult: MetadataEmbedder.EmbedResult) {
+            self.outputDirectory = outputDirectory
+            self.trackFiles = trackFiles
+            self.albumTitle = albumTitle
+            self.performer = performer
+            self.coverEmbedded = coverEmbedded
+            self.metadataResult = metadataResult
+        }
+
+        @available(*, deprecated, message: "Use process() → EngineOutcome instead")
+        public init(from outcome: EngineOutcome) throws {
+            guard let out = outcome.output else {
+                throw EngineError.splittingFailed("No output produced")
+            }
+            self.outputDirectory = out.outputDirectory
+            self.trackFiles = out.trackFiles
+            self.albumTitle = out.albumTitle
+            self.performer = out.performer
+            self.coverEmbedded = out.coverEmbedded
+            self.metadataResult = out.metadataResult
+        }
     }
 
     public struct LogHandler: @unchecked Sendable {
@@ -49,6 +139,8 @@ public actor TrackSplitterEngine {
     private let logHandler: LogHandler?
     /// NonisolatedUnsafe to allow cross-thread cancellation (e.g. MainActor cancel button).
     private nonisolated(unsafe) var _isCancelled = false
+    /// Holds the output of the most recent `process()` call, so `cleanup()` knows what to delete.
+    private var _lastOutput: Output?
 
     public init(logHandler: LogHandler? = nil) {
         self.logHandler = logHandler
@@ -69,24 +161,46 @@ public actor TrackSplitterEngine {
         logHandler?.log(msg)
     }
 
+    /// Delete the output files and directory from the last `process()` run.
+    /// Call this when the caller chooses not to keep a partial-success result.
+    public func cleanup() {
+        guard let out = _lastOutput else { return }
+        for file in out.trackFiles {
+            try? FileManager.default.removeItem(at: file)
+        }
+        try? FileManager.default.removeItem(at: out.outputDirectory)
+        _lastOutput = nil
+    }
+
     /// Process an audio file + CUE sheet and produce individual track files with metadata.
+    ///
+    /// Returns `EngineOutcome` — use `.status` to distinguish:
+    /// - `.success`: everything worked
+    /// - `.partialSuccess`: split files exist, metadata partially/fully failed — caller decides whether to `cleanup()`
+    /// - `.failure`: nothing usable was produced (pre-split error, or split itself failed)
+    ///
     /// - Parameters:
     ///   - inputURL: Source audio file
     ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
     ///     `.flac` = re-encode to FLAC (lossless, smaller file).
     ///     `.wav` = re-encode to WAV (lossless PCM, larger file).
-    public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async throws -> Result {
+    public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async -> EngineOutcome {
         _isCancelled = false  // Reset cancellation for each new process run
         log("📂 Input: \(inputURL.lastPathComponent)")
 
         // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
         guard let cueURL = findCue(for: inputURL) else {
-            throw EngineError.noCueFile(inputURL)
+            return .failure(message: EngineError.noCueFile(inputURL).localizedDescription)
         }
         log("📋 CUE found: \(cueURL.lastPathComponent)")
 
         // 2. Parse CUE (handles Chinese encodings via Big5/CP950 detection)
-        let (tracks, albumTitle, performer, cueFile, cueRem) = try parseCue(at: cueURL)
+        let (tracks, albumTitle, performer, cueFile, cueRem): ([CueTrack], String?, String?, CueFile?, CueRem)
+        do {
+            (tracks, albumTitle, performer, cueFile, cueRem) = try parseCue(at: cueURL)
+        } catch {
+            return .failure(message: "CUE parse error: \(error.localizedDescription)")
+        }
         log("🎵 Tracks: \(tracks.count) | Album: \(albumTitle ?? "—") | Artist: \(performer ?? "—")")
         log("📋 REM: date=\(cueRem.date ?? "—") genre=\(cueRem.genre ?? "—") comment=\(cueRem.comment ?? "—") composer=\(cueRem.composer ?? "—") discNumber=\(cueRem.discNumber ?? "—")")
 
@@ -95,14 +209,17 @@ public actor TrackSplitterEngine {
             let cueDeclaredName = cf.resolvedURL.lastPathComponent
             let similarity = stringSimilarity(cueDeclaredName, inputURL.lastPathComponent)
             if similarity < 0.80 {
-                log("⚠️  CUE FILE mismatch — CUE: \"\(cf.path)\", actual: \"\(inputURL.lastPathComponent)\" (similarity: \(String(format: "%.0f", similarity * 100))%)")
-                throw EngineError.cueFileMismatch(cueDeclaredFile: cf.path, actualAudioFile: inputURL.lastPathComponent)
+                let msg = EngineError.cueFileMismatch(cueDeclaredFile: cf.path, actualAudioFile: inputURL.lastPathComponent).localizedDescription
+                log("⚠️  \(msg)")
+                return .failure(message: msg)
             } else {
                 log("📋 CUE FILE field similarity: \(String(format: "%.0f", similarity * 100))% — fuzzy-matched (encoding may differ)")
             }
         }
 
-        guard !tracks.isEmpty else { throw EngineError.emptyTracks }
+        guard !tracks.isEmpty else {
+            return .failure(message: EngineError.emptyTracks.localizedDescription)
+        }
 
         // 3. Create output directory (use sanitized name to avoid filesystem issues)
         let albumDisplayName = albumTitle ?? inputURL.deletingPathExtension().lastPathComponent
@@ -110,7 +227,6 @@ public actor TrackSplitterEngine {
         let parentDir = inputURL.deletingLastPathComponent()
         let outDir = splitter.resolveUniqueOutputDirectory(baseDir: parentDir, safeName: albumSafeName)
 
-        // Report actual directory used if it diverges from display name
         if albumDisplayName != albumSafeName {
             log("🗂  Album display name: \"\(albumDisplayName)\" → filesystem: \"\(outDir.lastPathComponent)\"")
         }
@@ -118,7 +234,7 @@ public actor TrackSplitterEngine {
         do {
             try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
         } catch {
-            throw EngineError.outputDirCreationFailed
+            return .failure(message: EngineError.outputDirCreationFailed.localizedDescription)
         }
         log("📁 Output dir: \(outDir.path)")
 
@@ -132,9 +248,9 @@ public actor TrackSplitterEngine {
             log("⚠️  Cover fetch failed (continuing without cover): \(error.localizedDescription)")
         }
 
-        // 5. Split audio
+        // 5. Split audio — split failure is always fatal (nothing on disk)
         log("✂️  Starting split with ffmpeg...")
-        let splitTracks: [URL]
+        var splitTracks: [URL] = []
         do {
             splitTracks = try await splitter.split(
                 file: inputURL,
@@ -150,17 +266,21 @@ public actor TrackSplitterEngine {
             }
             log("✅  Split complete: \(splitTracks.count) files")
         } catch let error as AudioSplitter.SplitError {
-            if error.localizedDescription.contains("Cancelled") {
-                throw EngineError.splittingCancelled
-            }
-            throw EngineError.splittingFailed(error.localizedDescription)
+            let msg = error.localizedDescription.contains("Cancelled")
+                ? EngineError.splittingCancelled.localizedDescription
+                : EngineError.splittingFailed(error.localizedDescription).localizedDescription
+            for file in splitTracks { try? FileManager.default.removeItem(at: file) }
+            try? FileManager.default.removeItem(at: outDir)
+            return .failure(message: msg)
         } catch {
-            throw EngineError.splittingFailed(error.localizedDescription)
+            for file in splitTracks { try? FileManager.default.removeItem(at: file) }
+            try? FileManager.default.removeItem(at: outDir)
+            return .failure(message: EngineError.splittingFailed(error.localizedDescription).localizedDescription)
         }
 
-        // 6. Embed metadata (fatal on failure)
-        let metadataResult: MetadataEmbedder.EmbedResult
+        // 6. Embed metadata — partial metadata failure is now partialSuccess, not fatal
         log("🏷  Embedding metadata...")
+        let metadataResult: MetadataEmbedder.EmbedResult
         do {
             metadataResult = try await embedder.embedBatch(
                 files: zip(splitTracks, tracks).map { (url: $0.0, title: $0.1.title, trackNumber: $0.1.index) },
@@ -174,24 +294,40 @@ public actor TrackSplitterEngine {
                 totalTracks: tracks.count,
                 coverData: coverData
             )
-            if metadataResult.isFullySuccessful {
-                log("✅  Metadata embedded for all \(metadataResult.succeeded) tracks")
-            } else if metadataResult.isPartiallySuccessful {
-                log("⚠️  Metadata partially embedded: \(metadataResult.succeeded)/\(metadataResult.total) succeeded, \(metadataResult.failed) failed")
-            } else {
-                log("❌  Metadata embedding failed for all \(metadataResult.failed) tracks")
-                throw EngineError.metadataFailed(
-                    metadataResult.failures.joined(separator: "; ")
-                )
-            }
         } catch {
-            log("❌  Metadata embedding failed: \(error.localizedDescription)")
-            throw EngineError.metadataFailed(error.localizedDescription)
+            // Metadata script crashed — treat as partial success with no metadata written
+            log("⚠️  Metadata embedding threw (treating as partial success): \(error.localizedDescription)")
+            metadataResult = MetadataEmbedder.EmbedResult(
+                total: splitTracks.count,
+                succeeded: 0,
+                failed: splitTracks.count,
+                failures: [error.localizedDescription],
+                coverWasSkipped: false
+            )
         }
 
-        return Result(outputDirectory: outDir, trackFiles: splitTracks,
-                      albumTitle: albumTitle, performer: performer,
-                      coverEmbedded: coverData != nil && !metadataResult.coverWasSkipped,
-                      metadataResult: metadataResult)
+        if metadataResult.isFullySuccessful {
+            log("✅  Metadata embedded for all \(metadataResult.succeeded) tracks")
+        } else if metadataResult.isPartiallySuccessful {
+            log("⚠️  Metadata partially embedded: \(metadataResult.succeeded)/\(metadataResult.total) succeeded, \(metadataResult.failed) failed")
+        } else {
+            log("⚠️  Metadata embedding failed for all \(metadataResult.failed) tracks — returning partialSuccess with split files intact")
+        }
+
+        let output = Output(
+            outputDirectory: outDir,
+            trackFiles: splitTracks,
+            albumTitle: albumTitle,
+            performer: performer,
+            coverEmbedded: coverData != nil && !metadataResult.coverWasSkipped,
+            metadataResult: metadataResult
+        )
+        _lastOutput = output
+
+        if metadataResult.isFullySuccessful {
+            return .success(output)
+        } else {
+            return .partialSuccess(output, metadataFailures: metadataResult.failures)
+        }
     }
 }

--- a/Tests/EngineOutcomeTests.swift
+++ b/Tests/EngineOutcomeTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+@testable import TrackSplitterLib
+import XCTest
+
+/// Tests for EngineOutcome model and cleanup() behavior.
+final class EngineOutcomeTests: XCTestCase {
+
+    // MARK: - Outcome.Status classification
+
+    func testSuccess_hasSuccessStatus() {
+        let output = makeOutput(trackCount: 3)
+        let outcome = TrackSplitterEngine.EngineOutcome.success(output)
+        XCTAssertEqual(outcome.status, .success)
+        XCTAssertTrue(outcome.output != nil)
+    }
+
+    func testPartialSuccess_hasPartialSuccessStatus() {
+        let output = makeOutput(trackCount: 3)
+        let outcome = TrackSplitterEngine.EngineOutcome.partialSuccess(output, metadataFailures: ["track2.flac: error"])
+        XCTAssertEqual(outcome.status, .partialSuccess)
+        XCTAssertTrue(outcome.output != nil)
+    }
+
+    func testFailure_hasFailureStatus() {
+        let outcome = TrackSplitterEngine.EngineOutcome.failure(message: "no cue file")
+        XCTAssertEqual(outcome.status, .failure)
+        XCTAssertNil(outcome.output)
+    }
+
+    // MARK: - Outcome.summary
+
+    func testSuccessSummary_containsTrackCount() {
+        let output = makeOutput(trackCount: 5)
+        let outcome = TrackSplitterEngine.EngineOutcome.success(output)
+        let summary = outcome.summary
+        XCTAssertTrue(summary.contains("5"))
+        XCTAssertTrue(summary.contains("成功"))
+    }
+
+    func testPartialSuccessSummary_containsTrackCountAndMetadataFailures() {
+        let output = makeOutput(trackCount: 4)
+        let outcome = TrackSplitterEngine.EngineOutcome.partialSuccess(
+            output,
+            metadataFailures: ["a.flac: bad tags", "b.flac: io error"]
+        )
+        let summary = outcome.summary
+        XCTAssertTrue(summary.contains("4"))
+        XCTAssertTrue(summary.contains("2")) // 2 metadata failures
+    }
+
+    func testFailureSummary_containsMessage() {
+        let outcome = TrackSplitterEngine.EngineOutcome.failure(message: "splitting cancelled")
+        XCTAssertTrue(outcome.summary.contains("splitting cancelled"))
+    }
+
+    // MARK: - Outcome.output accessor
+
+    func testOutputAccessor_returnsOutputForSuccess() {
+        let output = makeOutput(trackCount: 2)
+        let outcome = TrackSplitterEngine.EngineOutcome.success(output)
+        XCTAssertEqual(outcome.output?.trackFiles.count, 2)
+    }
+
+    func testOutputAccessor_returnsOutputForPartialSuccess() {
+        let output = makeOutput(trackCount: 2)
+        let outcome = TrackSplitterEngine.EngineOutcome.partialSuccess(output, metadataFailures: [])
+        XCTAssertEqual(outcome.output?.trackFiles.count, 2)
+    }
+
+    func testOutputAccessor_returnsNilForFailure() {
+        let outcome = TrackSplitterEngine.EngineOutcome.failure(message: "boom")
+        XCTAssertNil(outcome.output)
+    }
+
+    // MARK: - Result.init(from:) deprecated path
+
+    func testLegacyResultInit_fromSuccess() throws {
+        let output = makeOutput(trackCount: 3)
+        let outcome = TrackSplitterEngine.EngineOutcome.success(output)
+        let result = try TrackSplitterEngine.Result(from: outcome)
+        XCTAssertEqual(result.trackFiles.count, 3)
+        XCTAssertEqual(result.albumTitle, "Test Album")
+    }
+
+    func testLegacyResultInit_fromPartialSuccess() throws {
+        let output = makeOutput(trackCount: 3)
+        let outcome = TrackSplitterEngine.EngineOutcome.partialSuccess(output, metadataFailures: ["err"])
+        let result = try TrackSplitterEngine.Result(from: outcome)
+        XCTAssertEqual(result.trackFiles.count, 3)
+    }
+
+    func testLegacyResultInit_fromFailure_throws() {
+        let outcome = TrackSplitterEngine.EngineOutcome.failure(message: "no output")
+        do {
+            _ = try TrackSplitterEngine.Result(from: outcome)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Expected
+        }
+    }
+
+    // MARK: - cleanup()
+
+    func testCleanup_onEmptyEngine_doesNotCrash() async {
+        let engine = TrackSplitterEngine()
+        // Should not throw even when _lastOutput is nil
+        await engine.cleanup()
+    }
+
+    func testStaticCleanup_deletesOutputFilesAndDirectory() throws {
+        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        let trackFile = tmpDir.appendingPathComponent("track1.flac")
+        try "fake audio data".data(using: .utf8)!.write(to: trackFile)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: trackFile.path))
+
+        let output = TrackSplitterEngine.Output(
+            outputDirectory: tmpDir,
+            trackFiles: [trackFile],
+            albumTitle: nil,
+            performer: nil,
+            coverEmbedded: false,
+            metadataResult: MetadataEmbedder.EmbedResult(
+                total: 1, succeeded: 1, failed: 0, failures: [], coverWasSkipped: false
+            )
+        )
+
+        TrackSplitterEngine.cleanup(output: output)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: trackFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tmpDir.path))
+    }
+
+    // MARK: - Helpers
+
+    private func makeOutput(trackCount: Int, albumName: String = "Test Album") -> TrackSplitterEngine.Output {
+        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        // Note: we don't actually create the directory — Output just holds the URL.
+        let files = (0..<trackCount).map { tmpDir.appendingPathComponent("track\($0 + 1).flac") }
+        return TrackSplitterEngine.Output(
+            outputDirectory: tmpDir,
+            trackFiles: files,
+            albumTitle: albumName,
+            performer: "Test Artist",
+            coverEmbedded: true,
+            metadataResult: MetadataEmbedder.EmbedResult(
+                total: trackCount,
+                succeeded: trackCount,
+                failed: 0,
+                failures: [],
+                coverWasSkipped: false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 收口 #27

**问题**：当音频拆分成功但 metadata 嵌入失败时，引擎把整件事当成 fatal error 抛异常，但磁盘上已有可用的音频文件。用户无法区分"完全成功 / 音频成功但 metadata 失败 / 完全失败"三种状态。

**解决方案**：

- 新增 `EngineOutcome` 枚举，显式建模 `.success / .partialSuccess / .failure`
- `process()` 现在返回 `EngineOutcome`：拆分失败 → `.failure`（自动清理）；metadata 部分/全部失败 → `.partialSuccess`（保留拆分文件）
- 新增 `cleanup()` 实例方法和 `static cleanup(output:)` 静态方法：caller 可选择不保留 partial-success 结果时主动清理
- CLI 区分三种状态输出对应消息（不含任何未实现的 flag 引用）
- GUI `SplitterViewModel` 已能正确处理 `partialSuccess` 并展示详情
- 新增 `EngineOutcomeTests`（14 tests），覆盖 status 分类 / summary 内容 / output accessor / 遗留 `Result.init(from:)` / `cleanup()`

**验收**：
- [x] `swift test` 全绿（78 tests，含新增 14 个）
- [x] `swift build` 成功（lib + CLI + GUI）
- [x] CLI 输出区分 `.success / .partialSuccess / .failure` 三种消息，无未实现的 flag 引用