### PR TITLE
fix: add environment pre-flight check and MetadataWriter adapter (#31)

### DIFF
--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -16,7 +16,7 @@ public enum EnvironmentIssue: Sendable {
         case .pythonVersionTooOld(let version, let minimum):
             return "Python \(version) is too old. Please upgrade to Python \(minimum) or later."
         case .mutagenNotImportable:
-            return "Python package 'mutagen' is not installed. Run: python3 -m pip install mutagen --break-system-packages"
+            return "Python package 'mutagen' is not installed. Run: python3 -m pip install mutagen  # or use a venv: python3 -m venv ~/.tracksplitter-venv && ~/.tracksplitter-venv/bin/pip install mutagen"
         case .scriptNotFound:
             return "embed_metadata.py could not be located. This file should be bundled with the app. Please re-install TrackSplitter."
         }

--- a/Library/MetadataEmbedder.swift
+++ b/Library/MetadataEmbedder.swift
@@ -1,32 +1,146 @@
 import Foundation
 
-/// Bridges to embed_metadata.py to write FLAC tags and cover art.
-public actor MetadataEmbedder {
+// MARK: - Environment Diagnostics
 
-    public enum EmbedError: Error, LocalizedError {
+/// A single environment problem detected during pre-flight checks.
+public enum EnvironmentIssue: Sendable {
+    case pythonNotFound(searchedPaths: [String])
+    case pythonVersionTooOld(version: String, minimum: String)
+    case mutagenNotImportable(cause: String)
+    case scriptNotFound(searchedPaths: [String])
+
+    public var remediation: String {
+        switch self {
+        case .pythonNotFound:
+            return "Python 3 not found. Install Python 3 from https://www.python.org or `brew install python3`, then ensure it is in your PATH."
+        case .pythonVersionTooOld(let version, let minimum):
+            return "Python \(version) is too old. Please upgrade to Python \(minimum) or later."
+        case .mutagenNotImportable:
+            return "Python package 'mutagen' is not installed. Run: python3 -m pip install mutagen --break-system-packages"
+        case .scriptNotFound:
+            return "embed_metadata.py could not be located. This file should be bundled with the app. Please re-install TrackSplitter."
+        }
+    }
+
+    public var summary: String {
+        switch self {
+        case .pythonNotFound: return "Python 3 not found"
+        case .pythonVersionTooOld(let version, _): return "Python \(version) too old"
+        case .mutagenNotImportable: return "mutagen not importable"
+        case .scriptNotFound: return "embed_metadata.py not found"
+        }
+    }
+}
+
+/// Result of a pre-flight environment check.
+public struct EnvironmentReport: Sendable {
+    /// All issues found. Empty if the environment is fully healthy.
+    public let issues: [EnvironmentIssue]
+    /// The Python path that will be used, if found.
+    public let pythonPath: String?
+    /// The script path that will be used, if found.
+    public let scriptPath: String?
+    /// Python version string, if available.
+    public let pythonVersion: String?
+
+    public var isHealthy: Bool { issues.isEmpty }
+
+    public init(issues: [EnvironmentIssue], pythonPath: String?, scriptPath: String?, pythonVersion: String?) {
+        self.issues = issues
+        self.pythonPath = pythonPath
+        self.scriptPath = scriptPath
+        self.pythonVersion = pythonVersion
+    }
+}
+
+// MARK: - Errors
+
+/// Errors from the metadata writing layer.
+public enum EmbedError: Error, LocalizedError {
+    case pythonNotFound
+    case scriptNotFound
+    case encodingFailed
+    case tempFileFailed
+    case scriptFailed(String)
+    case environmentCheckFailed([EnvironmentIssue])
+
+    public var errorDescription: String? {
+        switch self {
+        case .pythonNotFound: return "Python 3 not found in PATH"
+        case .scriptNotFound: return "embed_metadata.py not found"
+        case .encodingFailed: return "Failed to encode metadata as JSON"
+        case .tempFileFailed: return "Failed to write temp JSON file"
+        case .scriptFailed(let msg): return "Metadata script error: \(msg)"
+        case .environmentCheckFailed(let issues):
+            let summaries = issues.map { $0.summary }.joined(separator: "; ")
+            return "Environment check failed: \(summaries)"
+        }
+    }
+}
+
+// MARK: - Embed Result
+
+public struct EmbedResult: Sendable {
+    public let total: Int
+    public let succeeded: Int
+    public let failed: Int
+    public let failures: [String]
+    /// True if any file had cover art skipped (e.g., WAV doesn't support embedded cover art).
+    public let coverWasSkipped: Bool
+
+    public var isFullySuccessful: Bool { failed == 0 }
+    public var isPartiallySuccessful: Bool { succeeded > 0 && failed > 0 }
+
+    public init(total: Int, succeeded: Int, failed: Int, failures: [String], coverWasSkipped: Bool) {
+        self.total = total
+        self.succeeded = succeeded
+        self.failed = failed
+        self.failures = failures
+        self.coverWasSkipped = coverWasSkipped
+    }
+}
+
+// MARK: - MetadataWriter Protocol
+
+/// Protocol for metadata writing implementations.
+/// Allows swapping the backend (Python/mutagen, ffmpeg, AVFoundation, etc.) without changing the engine.
+public protocol MetadataWriter: Sendable {
+    /// Write metadata to the given batch of files.
+    func embedBatch(
+        files: [(url: URL, title: String, trackNumber: Int)],
+        artist: String,
+        album: String,
+        year: String,
+        genre: String,
+        comment: String?,
+        composer: String?,
+        discNumber: String?,
+        totalTracks: Int,
+        coverData: Data?
+    ) async throws -> EmbedResult
+
+    /// Perform a pre-flight environment check.
+    func checkEnvironment() async -> EnvironmentReport
+}
+
+// MARK: - Python/mutagen Adapter
+
+/// Default adapter using Python + mutagen via embed_metadata.py.
+public actor PythonMetadataAdapter: MetadataWriter {
+
+    public enum AdapterError: Error {
         case pythonNotFound
         case scriptNotFound
         case encodingFailed
         case tempFileFailed
         case scriptFailed(String)
-
-        public var errorDescription: String? {
-            switch self {
-            case .pythonNotFound: return "Python 3 not found in PATH"
-            case .scriptNotFound: return "embed_metadata.py not found"
-            case .encodingFailed: return "Failed to encode metadata as JSON"
-            case .tempFileFailed: return "Failed to write temp JSON file"
-            case .scriptFailed(let msg): return "Metadata script error: \(msg)"
-            }
-        }
     }
 
-    public struct EmbedResult: Sendable {
+    public struct AdapterEmbedResult: Sendable {
         public let total: Int
         public let succeeded: Int
         public let failed: Int
         public let failures: [String]
-        /// True if any file had cover art skipped (e.g., WAV doesn't support embedded cover art).
         public let coverWasSkipped: Bool
 
         public var isFullySuccessful: Bool { failed == 0 }
@@ -39,36 +153,17 @@ public actor MetadataEmbedder {
             self.failures = failures
             self.coverWasSkipped = coverWasSkipped
         }
-    }
 
-    /// Parses the stdout lines emitted by embed_metadata.py.
-    /// Exposed for unit testing — call this directly instead of duplicating the logic.
-    static func parseOutput(_ stdout: String) -> (succeeded: Int, failed: Int, failures: [String], coverWasSkipped: Bool) {
-        var succeeded = 0
-        var failed = 0
-        var failures: [String] = []
-        var coverWasSkipped = false
-
-        for line in stdout.components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
-            if line.hasPrefix("DONE: ") {
-                succeeded += 1
-            } else if line.hasPrefix("SKIP: ") {
-                succeeded += 1
-                if line.contains("cover art skipped") {
-                    coverWasSkipped = true
-                }
-            } else if line.hasPrefix("ERROR: ") {
-                failed += 1
-                failures.append(String(line.dropFirst(7)))
-            }
+        public func toEmbedResult() -> EmbedResult {
+            EmbedResult(total: total, succeeded: succeeded, failed: failed,
+                        failures: failures, coverWasSkipped: coverWasSkipped)
         }
-
-        return (succeeded, failed, failures, coverWasSkipped)
     }
 
     private let pythonPath: String
     private let scriptPath: String
     private let timeoutSeconds: Double?
+    private var _cachedReport: EnvironmentReport?
 
     public init(timeoutSeconds: Double? = 60) {
         self.pythonPath = Self.findPython()
@@ -76,25 +171,23 @@ public actor MetadataEmbedder {
         self.timeoutSeconds = timeoutSeconds
     }
 
+    // MARK: - Environment
+
     private static func findPython() -> String {
         let candidates = ["/opt/homebrew/bin/python3", "/opt/homebrew/bin/python3.14", "/usr/local/bin/python3", "python3"]
         return candidates.first { FileManager.default.isExecutableFile(atPath: $0) } ?? "python3"
     }
 
-    /// Walk up from the executable's directory to find embed_metadata.py.
-    /// Handles SPM development builds, release builds, and installed layouts.
     private static func locateScript() -> String {
-        // Primary: SwiftPM resource bundle (embed_metadata.py is in Library/Resources/)
         if let bundleURL = Bundle.module.url(forResource: "embed_metadata", withExtension: "py"),
            FileManager.default.isReadableFile(atPath: bundleURL.path) {
             return bundleURL.path
         }
 
-        // Fallback: relative-path search for development / installed layouts
         let exeDir = (CommandLine.arguments.first.map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
             ?? FileManager.default.currentDirectoryPath)
-
         let exeURL = URL(fileURLWithPath: exeDir)
+
         let searchPaths: [URL] = [
             exeURL.appendingPathComponent("embed_metadata.py"),
             exeURL.appendingPathComponent("Resources").appendingPathComponent("embed_metadata.py"),
@@ -116,8 +209,86 @@ public actor MetadataEmbedder {
         return "embed_metadata.py"
     }
 
-    /// Embed metadata into multiple FLAC files at once.
-    /// Returns a per-file result indicating success/failure for each track.
+    /// Returns the Python version string, or nil if python was not found.
+    private func pythonVersion() async -> String? {
+        guard FileManager.default.isExecutableFile(atPath: pythonPath) else { return nil }
+        let runner = ProcessRunner(timeoutSeconds: 5)
+        do {
+            let (stdout, _, rc) = try await runner.runCollecting(executable: pythonPath, arguments: ["-c", "import sys; print(sys.version_info.major + '.' + sys.version_info.minor)"])
+            guard rc == 0 else { return nil }
+            return stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Checks whether mutagen can be imported by the python at pythonPath.
+    private func checkMutagenImport() async -> String? {
+        guard FileManager.default.isExecutableFile(atPath: pythonPath) else { return "Python not found" }
+        let runner = ProcessRunner(timeoutSeconds: 10)
+        do {
+            let (stdout, stderr, rc) = try await runner.runCollecting(
+                executable: pythonPath,
+                arguments: ["-c", "import mutagen; print('OK')"]
+            )
+            if rc == 0 && stdout.contains("OK") { return nil }
+            return rc != 0 ? "python exit \(rc): \(stderr.prefix(80))" : "mutagen not importable"
+        } catch {
+            return "failed to run: \(error.localizedDescription)"
+        }
+    }
+
+    public func checkEnvironment() async -> EnvironmentReport {
+        if let cached = _cachedReport { return cached }
+
+        var issues: [EnvironmentIssue] = []
+        var version: String? = nil
+        let scriptPaths = Self.allScriptSearchPaths()
+
+        if !FileManager.default.isExecutableFile(atPath: pythonPath) {
+            issues.append(.pythonNotFound(searchedPaths: Self.pythonSearchPaths()))
+        } else {
+            version = await pythonVersion()
+            if let v = version, v.hasPrefix("2.") || v.hasPrefix("3.0") || v.hasPrefix("3.1") || v.hasPrefix("3.2") || v.hasPrefix("3.3") || v.hasPrefix("3.4") || v.hasPrefix("3.5") {
+                issues.append(.pythonVersionTooOld(version: v, minimum: "3.6"))
+            }
+
+            if let mutagenErr = await checkMutagenImport() {
+                issues.append(.mutagenNotImportable(cause: mutagenErr))
+            }
+        }
+
+        if !FileManager.default.isReadableFile(atPath: scriptPath) {
+            issues.append(.scriptNotFound(searchedPaths: scriptPaths))
+        }
+
+        let report = EnvironmentReport(
+            issues: issues,
+            pythonPath: FileManager.default.isExecutableFile(atPath: pythonPath) ? pythonPath : nil,
+            scriptPath: FileManager.default.isReadableFile(atPath: scriptPath) ? scriptPath : nil,
+            pythonVersion: version
+        )
+        _cachedReport = report
+        return report
+    }
+
+    private static func pythonSearchPaths() -> [String] {
+        ["/opt/homebrew/bin/python3", "/opt/homebrew/bin/python3.14", "/usr/local/bin/python3", "python3"]
+    }
+
+    private static func allScriptSearchPaths() -> [String] {
+        let exeDir = (CommandLine.arguments.first.map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
+            ?? FileManager.default.currentDirectoryPath)
+        let exeURL = URL(fileURLWithPath: exeDir)
+        return [
+            exeURL.appendingPathComponent("embed_metadata.py").path,
+            exeURL.appendingPathComponent("Resources").appendingPathComponent("embed_metadata.py").path,
+            exeURL.appendingPathComponent("Library/Resources").appendingPathComponent("embed_metadata.py").path,
+        ]
+    }
+
+    // MARK: - Embed
+
     public func embedBatch(
         files: [(url: URL, title: String, trackNumber: Int)],
         artist: String,
@@ -150,7 +321,7 @@ public actor MetadataEmbedder {
         let payload = Payload(files: items, coverData: coverB64)
 
         guard let jsonData = try? JSONEncoder().encode(payload) else {
-            throw EmbedError.encodingFailed
+            throw AdapterError.encodingFailed
         }
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -158,7 +329,7 @@ public actor MetadataEmbedder {
         do {
             try jsonData.write(to: tempFile)
         } catch {
-            throw EmbedError.tempFileFailed
+            throw AdapterError.tempFileFailed
         }
 
         defer { try? FileManager.default.removeItem(at: tempFile) }
@@ -168,22 +339,22 @@ public actor MetadataEmbedder {
         let parsed = Self.parseOutput(stdout)
 
         if rc != 0 && parsed.succeeded == 0 && parsed.failed == 0 {
-            return EmbedResult(
+            return AdapterEmbedResult(
                 total: files.count,
                 succeeded: 0,
                 failed: files.count,
                 failures: ["脚本执行失败（RC=\(rc)）：\(stderr.prefix(100))"],
                 coverWasSkipped: parsed.coverWasSkipped
-            )
+            ).toEmbedResult()
         }
 
-        return EmbedResult(
+        return AdapterEmbedResult(
             total: files.count,
             succeeded: parsed.succeeded,
             failed: parsed.failed,
             failures: parsed.failures,
             coverWasSkipped: parsed.coverWasSkipped
-        )
+        ).toEmbedResult()
     }
 
     private func runScript(jsonFile: URL) async throws -> (stdout: String, stderr: String, rc: Int32) {
@@ -196,11 +367,87 @@ public actor MetadataEmbedder {
             return (stdout, stderr, rc)
         } catch let error as ProcessRunnerError {
             if case .timeout = error {
-                throw EmbedError.scriptFailed("Python script timed out after \(Int(timeoutSeconds ?? 0))s")
+                throw AdapterError.scriptFailed("Python script timed out after \(Int(timeoutSeconds ?? 0))s")
             }
             throw error
         } catch {
             throw error
         }
+    }
+
+    /// Parses the stdout lines emitted by embed_metadata.py.
+    static func parseOutput(_ stdout: String) -> (succeeded: Int, failed: Int, failures: [String], coverWasSkipped: Bool) {
+        var succeeded = 0
+        var failed = 0
+        var failures: [String] = []
+        var coverWasSkipped = false
+
+        for line in stdout.components(separatedBy: .newlines).filter({ !$0.isEmpty }) {
+            if line.hasPrefix("DONE: ") {
+                succeeded += 1
+            } else if line.hasPrefix("SKIP: ") {
+                succeeded += 1
+                if line.contains("cover art skipped") {
+                    coverWasSkipped = true
+                }
+            } else if line.hasPrefix("ERROR: ") {
+                failed += 1
+                failures.append(String(line.dropFirst(7)))
+            }
+        }
+
+        return (succeeded, failed, failures, coverWasSkipped)
+    }
+}
+
+// MARK: - MetadataEmbedder (adapter-based wrapper)
+
+/// Bridges to a metadata writing backend.
+///
+/// Defaults to `PythonMetadataAdapter` but accepts any `MetadataWriter` implementation.
+public actor MetadataEmbedder {
+
+    private let writer: any MetadataWriter
+
+    /// Creates a MetadataEmbedder using the default Python/mutagen backend.
+    public init(timeoutSeconds: Double? = 60) {
+        self.writer = PythonMetadataAdapter(timeoutSeconds: timeoutSeconds)
+    }
+
+    /// Creates a MetadataEmbedder with a custom writer (useful for testing or alternative backends).
+    public init(writer: any MetadataWriter) {
+        self.writer = writer
+    }
+
+    /// Perform a pre-flight environment check.
+    /// Call this before processing to fail fast with a clear diagnosis.
+    public func checkEnvironment() async -> EnvironmentReport {
+        await writer.checkEnvironment()
+    }
+
+    /// Embed metadata into multiple audio files at once.
+    public func embedBatch(
+        files: [(url: URL, title: String, trackNumber: Int)],
+        artist: String,
+        album: String,
+        year: String,
+        genre: String,
+        comment: String?,
+        composer: String?,
+        discNumber: String?,
+        totalTracks: Int,
+        coverData: Data?
+    ) async throws -> EmbedResult {
+        // Pre-flight check — fail fast with a clear diagnosis
+        let report = await checkEnvironment()
+        if !report.isHealthy {
+            throw EmbedError.environmentCheckFailed(report.issues)
+        }
+
+        return try await writer.embedBatch(
+            files: files, artist: artist, album: album, year: year, genre: genre,
+            comment: comment, composer: composer, discNumber: discNumber,
+            totalTracks: totalTracks, coverData: coverData
+        )
     }
 }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -195,21 +195,6 @@ public actor TrackSplitterEngine {
         _isCancelled = false  // Reset cancellation for each new process run
         log("📂 Input: \(inputURL.lastPathComponent)")
 
-        // 0. Pre-flight environment check — fail fast before any file operations
-        let envReport = await embedder.checkEnvironment()
-        if !envReport.isHealthy {
-            let issues = envReport.issues
-            let firstIssue = issues.first!
-            log("❌ Environment check failed: \(firstIssue.summary)")
-            for issue in issues {
-                log("   → \(issue.remediation)")
-            }
-            return .failure(message: "Environment check failed: \(firstIssue.summary)")
-        }
-        if let ver = envReport.pythonVersion {
-            log("🐍 Python \(ver) + mutagen OK | script: \(envReport.scriptPath ?? "unknown")")
-        }
-
         // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
         guard let cueURL = findCue(for: inputURL) else {
             return .failure(message: EngineError.noCueFile(inputURL).localizedDescription)
@@ -241,6 +226,21 @@ public actor TrackSplitterEngine {
 
         guard !tracks.isEmpty else {
             return .failure(message: EngineError.emptyTracks.localizedDescription)
+        }
+
+        // 2. Pre-flight environment check — after input validation, before any file system operations
+        let envReport = await embedder.checkEnvironment()
+        if !envReport.isHealthy {
+            let issues = envReport.issues
+            let firstIssue = issues.first!
+            log("❌ Environment check failed: \(firstIssue.summary)")
+            for issue in issues {
+                log("   → \(issue.remediation)")
+            }
+            return .failure(message: "Environment check failed: \(firstIssue.summary)")
+        }
+        if let ver = envReport.pythonVersion {
+            log("🐍 Python \(ver) + mutagen OK | script: \(envReport.scriptPath ?? "unknown")")
         }
 
         // 3. Create output directory (use sanitized name to avoid filesystem issues)

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -80,10 +80,10 @@ public actor TrackSplitterEngine {
         /// Whether cover art was successfully fetched and embedded.
         public let coverEmbedded: Bool
         /// Per-track metadata embedding result.
-        public let metadataResult: MetadataEmbedder.EmbedResult
+        public let metadataResult: EmbedResult
 
         public init(outputDirectory: URL, trackFiles: [URL], albumTitle: String?, performer: String?,
-                    coverEmbedded: Bool, metadataResult: MetadataEmbedder.EmbedResult) {
+                    coverEmbedded: Bool, metadataResult: EmbedResult) {
             self.outputDirectory = outputDirectory
             self.trackFiles = trackFiles
             self.albumTitle = albumTitle
@@ -101,10 +101,10 @@ public actor TrackSplitterEngine {
         public let albumTitle: String?
         public let performer: String?
         public let coverEmbedded: Bool
-        public let metadataResult: MetadataEmbedder.EmbedResult
+        public let metadataResult: EmbedResult
 
         public init(outputDirectory: URL, trackFiles: [URL], albumTitle: String?, performer: String?,
-                    coverEmbedded: Bool, metadataResult: MetadataEmbedder.EmbedResult) {
+                    coverEmbedded: Bool, metadataResult: EmbedResult) {
             self.outputDirectory = outputDirectory
             self.trackFiles = trackFiles
             self.albumTitle = albumTitle
@@ -194,6 +194,21 @@ public actor TrackSplitterEngine {
     public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async -> EngineOutcome {
         _isCancelled = false  // Reset cancellation for each new process run
         log("📂 Input: \(inputURL.lastPathComponent)")
+
+        // 0. Pre-flight environment check — fail fast before any file operations
+        let envReport = await embedder.checkEnvironment()
+        if !envReport.isHealthy {
+            let issues = envReport.issues
+            let firstIssue = issues.first!
+            log("❌ Environment check failed: \(firstIssue.summary)")
+            for issue in issues {
+                log("   → \(issue.remediation)")
+            }
+            return .failure(message: "Environment check failed: \(firstIssue.summary)")
+        }
+        if let ver = envReport.pythonVersion {
+            log("🐍 Python \(ver) + mutagen OK | script: \(envReport.scriptPath ?? "unknown")")
+        }
 
         // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
         guard let cueURL = findCue(for: inputURL) else {
@@ -287,7 +302,7 @@ public actor TrackSplitterEngine {
 
         // 6. Embed metadata — partial metadata failure is now partialSuccess, not fatal
         log("🏷  Embedding metadata...")
-        let metadataResult: MetadataEmbedder.EmbedResult
+        let metadataResult: EmbedResult
         do {
             metadataResult = try await embedder.embedBatch(
                 files: zip(splitTracks, tracks).map { (url: $0.0, title: $0.1.title, trackNumber: $0.1.index) },
@@ -304,7 +319,7 @@ public actor TrackSplitterEngine {
         } catch {
             // Metadata script crashed — treat as partial success with no metadata written
             log("⚠️  Metadata embedding threw (treating as partial success): \(error.localizedDescription)")
-            metadataResult = MetadataEmbedder.EmbedResult(
+            metadataResult = EmbedResult(
                 total: splitTracks.count,
                 succeeded: 0,
                 failed: splitTracks.count,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@
 
 - **macOS 13+**
 - **ffmpeg** — `brew install ffmpeg`
-- **Python 3 + mutagen** — `pip3 install mutagen --break-system-packages`
+- **Python 3 + mutagen** — recommended to install in a virtual environment:
+  ```bash
+  python3 -m venv ~/.tracksplitter-venv
+  ~/.tracksplitter-venv/bin/pip install mutagen
+  ```
+  Then invoke TrackSplitter with the venv activated, or adjust the shebang path.
 
 ## 从源码构建
 

--- a/Tests/EngineOutcomeTests.swift
+++ b/Tests/EngineOutcomeTests.swift
@@ -121,7 +121,7 @@ final class EngineOutcomeTests: XCTestCase {
             albumTitle: nil,
             performer: nil,
             coverEmbedded: false,
-            metadataResult: MetadataEmbedder.EmbedResult(
+            metadataResult: EmbedResult(
                 total: 1, succeeded: 1, failed: 0, failures: [], coverWasSkipped: false
             )
         )
@@ -144,7 +144,7 @@ final class EngineOutcomeTests: XCTestCase {
             albumTitle: albumName,
             performer: "Test Artist",
             coverEmbedded: true,
-            metadataResult: MetadataEmbedder.EmbedResult(
+            metadataResult: EmbedResult(
                 total: trackCount,
                 succeeded: trackCount,
                 failed: 0,

--- a/Tests/MetadataEmbedderResultTests.swift
+++ b/Tests/MetadataEmbedderResultTests.swift
@@ -2,15 +2,15 @@ import Foundation
 @testable import TrackSplitterLib
 import XCTest
 
-/// Tests for MetadataEmbedder stdout parsing and EmbedResult construction.
-/// Calls the production `MetadataEmbedder.parseOutput()` directly to ensure
+/// Tests for PythonMetadataAdapter stdout parsing and EmbedResult construction.
+/// Calls the production `PythonMetadataAdapter.parseOutput()` directly to ensure
 /// tests exercise the actual production code path.
 final class MetadataEmbedderResultTests: XCTestCase {
 
     // MARK: - EmbedResult computed properties
 
     func testFullySuccessful_allSucceeded() {
-        let result = MetadataEmbedder.EmbedResult(
+        let result = EmbedResult(
             total: 3, succeeded: 3, failed: 0, failures: [], coverWasSkipped: false
         )
         XCTAssertTrue(result.isFullySuccessful)
@@ -18,7 +18,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
     }
 
     func testFullySuccessful_allSucceededWithSkipped() {
-        let result = MetadataEmbedder.EmbedResult(
+        let result = EmbedResult(
             total: 3, succeeded: 3, failed: 0, failures: [], coverWasSkipped: true
         )
         XCTAssertTrue(result.isFullySuccessful)
@@ -27,7 +27,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
     }
 
     func testPartiallySuccessful() {
-        let result = MetadataEmbedder.EmbedResult(
+        let result = EmbedResult(
             total: 3, succeeded: 2, failed: 1, failures: ["file2.flac: encoding error"], coverWasSkipped: false
         )
         XCTAssertFalse(result.isFullySuccessful)
@@ -35,7 +35,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
     }
 
     func testAllFailed() {
-        let result = MetadataEmbedder.EmbedResult(
+        let result = EmbedResult(
             total: 3, succeeded: 0, failed: 3, failures: ["f1.flac", "f2.flac", "f3.flac"], coverWasSkipped: false
         )
         XCTAssertFalse(result.isFullySuccessful)
@@ -45,7 +45,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
 
     func testZeroTotals() {
         // With total=0 and no failures, isFullySuccessful is true (failed==0).
-        let result = MetadataEmbedder.EmbedResult(
+        let result = EmbedResult(
             total: 0, succeeded: 0, failed: 0, failures: [], coverWasSkipped: false
         )
         XCTAssertTrue(result.isFullySuccessful)
@@ -56,7 +56,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
 
     func testParseOutput_allDONE() {
         let stdout = "DONE: file1.flac\nDONE: file2.flac\n"
-        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
         XCTAssertEqual(parsed.succeeded, 2)
         XCTAssertEqual(parsed.failed, 0)
         XCTAssertTrue(parsed.failures.isEmpty)
@@ -69,7 +69,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
         SKIP: file2.wav (cover art skipped)
         ERROR: file3.mp3 invalid tag
         """
-        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
         XCTAssertEqual(parsed.succeeded, 2)
         XCTAssertEqual(parsed.failed, 1)
         XCTAssertEqual(parsed.failures, ["file3.mp3 invalid tag"])
@@ -78,14 +78,14 @@ final class MetadataEmbedderResultTests: XCTestCase {
 
     func testParseOutput_emptyLinesIgnored() {
         let stdout = "DONE: file1.flac\n\nDONE: file2.flac\n  \n"
-        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
         XCTAssertEqual(parsed.succeeded, 2)
         XCTAssertEqual(parsed.failed, 0)
     }
 
     func testParseOutput_noMatch() {
         let stdout = "something went wrong\nrandom output"
-        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
         XCTAssertEqual(parsed.succeeded, 0)
         XCTAssertEqual(parsed.failed, 0)
         XCTAssertTrue(parsed.failures.isEmpty)
@@ -93,7 +93,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
 
     func testParseOutput_coverWasSkippedOnly() {
         let stdout = "SKIP: track.wav (unsupported format, cover art skipped)"
-        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
         XCTAssertEqual(parsed.succeeded, 1)
         XCTAssertTrue(parsed.coverWasSkipped)
     }
@@ -104,7 +104,7 @@ final class MetadataEmbedderResultTests: XCTestCase {
         ERROR: b.flac: io error
         DONE: c.flac
         """
-        let parsed = MetadataEmbedder.parseOutput(stdout)
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
         XCTAssertEqual(parsed.succeeded, 1)
         XCTAssertEqual(parsed.failed, 2)
         XCTAssertEqual(parsed.failures, ["a.flac: permission denied", "b.flac: io error"])
@@ -114,8 +114,8 @@ final class MetadataEmbedderResultTests: XCTestCase {
 
     func testEmbedResult_roundTripFullySuccessful() {
         let stdout = "DONE: a.flac\nDONE: b.flac\nDONE: c.flac\n"
-        let parsed = MetadataEmbedder.parseOutput(stdout)
-        let result = MetadataEmbedder.EmbedResult(
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
+        let result = EmbedResult(
             total: 3,
             succeeded: parsed.succeeded,
             failed: parsed.failed,
@@ -132,8 +132,8 @@ final class MetadataEmbedderResultTests: XCTestCase {
         DONE: good.flac
         ERROR: bad.flac: permission denied
         """
-        let parsed = MetadataEmbedder.parseOutput(stdout)
-        let result = MetadataEmbedder.EmbedResult(
+        let parsed = PythonMetadataAdapter.parseOutput(stdout)
+        let result = EmbedResult(
             total: 2,
             succeeded: parsed.succeeded,
             failed: parsed.failed,


### PR DESCRIPTION
## 收口 #31

**问题**：metadata 写入依赖 Python + mutagen，但启动时无任何环境检测；失败时错误信息不清楚，用户难以判断是 Python 问题、mutagen 问题还是脚本路径问题。

**短期解决方案（本次）**：

### 环境预检（Environment Pre-flight Check）
- 新增 `EnvironmentIssue` 枚举，区分四类问题：
  - `pythonNotFound` — 报告搜索过的所有路径
  - `pythonVersionTooOld` — 报告当前版本和最低版本要求
  - `mutagenNotImportable` — 报告导入失败的具体原因（remediation 推荐 venv 安装，与 README 一致）
  - `scriptNotFound` — 报告搜索过的所有路径
- 每个 issue 带 `.remediation` 字段，给出具体修复命令
- `MetadataEmbedder.checkEnvironment()` 在首次调用时运行（结果缓存）
- 环境检查在 `Engine.process()` 中的位置：**CUE 解析和轨道验证之后、创建输出目录之前**；这样 basic input errors（无 CUE 文件、CUE 解析失败）优先于环境问题报告
- `EmbedError.environmentCheckFailed([EnvironmentIssue])` 携带所有诊断信息

### MetadataWriter 可替换适配层（Medium-term groundwork）
- 新增 `MetadataWriter` 协议，定义 `embedBatch(...)` 和 `checkEnvironment()`
- `PythonMetadataAdapter` 实现该协议，继续使用 embed_metadata.py
- `MetadataEmbedder` 持有 `any MetadataWriter`，默认使用 `PythonMetadataAdapter`
- 这为后续迁移到纯 Swift（AVFoundation/ffmpeg）路径扫清了架构障碍，无需改动 engine 层

### README 更新
- 移除 `--break-system-packages`（macOS 上有兼容性问题）
- 改为推荐 virtualenv 安装方式

**验收**：
- [x] `swift test` 全绿（78 tests）
- [x] `swift build` 成功（lib + CLI + GUI）
- [x] 环境检查在 CUE/轨道验证之后、输出目录创建之前执行
- [x] mutagen remediation 不含 `--break-system-packages`