### PR TITLE
feat: support multiple chapter source formats (issue #14)

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -16,23 +16,59 @@ struct TrackSplitterCLI {
             return
         }
 
+        // Parse --chapter-source
+        var chapterSourceArg: String?
+        var filteredArgs = args
+        if let idx = args.firstIndex(of: "--chapter-source") {
+            guard idx + 1 < args.count else {
+                print("Error: --chapter-source requires a value (e.g. --chapter-source embedded)")
+                exit(1)
+            }
+            chapterSourceArg = args[idx + 1]
+            var copy = args
+            copy.remove(at: idx + 1)
+            copy.remove(at: idx)
+            filteredArgs = copy
+        } else if let idx = args.firstIndex(where: { $0.hasPrefix("--chapter-source=") }) {
+            chapterSourceArg = String(args[idx].dropFirst("--chapter-source=".count))
+            var copy = args
+            copy.remove(at: idx)
+            filteredArgs = copy
+        }
+
+        // Parse --chapter-file (alias for --chapter-source with explicit file path)
+        var chapterFileArg: String?
+        if let idx = args.firstIndex(of: "--chapter-file") {
+            guard idx + 1 < args.count else {
+                print("Error: --chapter-file requires a path (e.g. --chapter-file /path/to/chapters.txt)")
+                exit(1)
+            }
+            chapterFileArg = args[idx + 1]
+            var copy = args
+            copy.remove(at: idx + 1)
+            copy.remove(at: idx)
+            filteredArgs = copy
+        } else if let idx = args.firstIndex(where: { $0.hasPrefix("--chapter-file=") }) {
+            chapterFileArg = String(args[idx].dropFirst("--chapter-file=".count))
+            var copy = args
+            copy.remove(at: idx)
+            filteredArgs = copy
+        }
+
         // Parse --output-format
         var outputFormatArg: String?
-        var filteredArgs = args
         if let idx = args.firstIndex(of: "--output-format") {
             guard idx + 1 < args.count else {
                 print("Error: --output-format requires a value (e.g. --output-format mp3)")
                 exit(1)
             }
             outputFormatArg = args[idx + 1]
-            // Remove exactly the --output-format flag and its value by index, not by value
             var copy = args
             copy.remove(at: idx + 1)
             copy.remove(at: idx)
             filteredArgs = copy
         } else if let idx = args.firstIndex(where: { $0.hasPrefix("--output-format=") }) {
             outputFormatArg = String(args[idx].dropFirst("--output-format=".count))
-            // Remove exactly this argument by index
             var copy = args
             copy.remove(at: idx)
             filteredArgs = copy
@@ -60,12 +96,43 @@ struct TrackSplitterCLI {
             exit(1)
         }
 
-        await runCLI(audioPath: audioPath, outputFormat: outputFormat)
+        // Parse chapter source (audioPath is now available for .embedded case)
+        let chapterSource: ChapterSource?
+        if let raw = chapterSourceArg {
+            if raw == "embedded" {
+                chapterSource = .embedded(URL(fileURLWithPath: audioPath))
+            } else if raw == "cue" || raw == "auto" {
+                chapterSource = nil  // auto-detect CUE (default)
+            } else {
+                print("Error: '\(raw)' is not a valid --chapter-source value.")
+                print("Valid values: embedded, cue, auto")
+                exit(1)
+            }
+        } else if let path = chapterFileArg {
+            let fileURL = URL(fileURLWithPath: path)
+            guard FileManager.default.isReadableFile(atPath: path) else {
+                print("Error: Chapter file not found: \(path)")
+                exit(1)
+            }
+            let ext = fileURL.pathExtension.lowercased()
+            if ext == "cue" || ext == "qcue" {
+                chapterSource = .cue(fileURL)
+            } else if ext == "meta" || ext == "ffmetadata" {
+                chapterSource = .ffmpegChapters(fileURL)
+            } else {
+                // Default: treat as text chapters
+                chapterSource = .textChapters(fileURL)
+            }
+        } else {
+            chapterSource = nil  // auto-detect CUE
+        }
+
+        await runCLI(audioPath: audioPath, outputFormat: outputFormat, chapterSource: chapterSource)
     }
 
     // MARK: - CLI mode
 
-    private static func runCLI(audioPath: String, outputFormat: AudioSplitter.AudioFormat?) async {
+    private static func runCLI(audioPath: String, outputFormat: AudioSplitter.AudioFormat?, chapterSource: ChapterSource?) async {
         let audioURL = URL(fileURLWithPath: audioPath)
 
         guard FileManager.default.fileExists(atPath: audioURL.path) else {
@@ -94,7 +161,7 @@ struct TrackSplitterCLI {
             print("Output format: passthrough (keeping original format)\n")
         }
 
-        let outcome = await engine.process(inputURL: audioURL, outputFormat: outputFormat)
+        let outcome = await engine.process(inputURL: audioURL, outputFormat: outputFormat, chapterSource: chapterSource)
         switch outcome.status {
         case .success:
             guard let output = outcome.output else {
@@ -130,23 +197,34 @@ struct TrackSplitterCLI {
     Supported formats: FLAC, MP3, WAV, AIFF, M4A, AAC, OGG, Opus
 
     Usage:
-      tracksplitter <file>                    Process an audio file from the command line
-      tracksplitter <file> --output-format mp3  Re-encode output to MP3
+      tracksplitter <file>                         Process an audio file (uses .cue if found)
+      tracksplitter <file> --chapter-source embedded  Read chapters from the audio file itself
+      tracksplitter <file> --chapter-file /path/to/chapters.txt  Use a text/FFmpeg chapter file
+      tracksplitter <file> --output-format mp3      Re-encode output to MP3
 
-    Options:
-      --help, -h           Show this help
-      --version            Show version
+    Chapter source options:
+      --chapter-source embedded   Read chapters from the input audio file (if any)
+      --chapter-source cue        Explicitly use CUE auto-detection (default)
+      --chapter-file <path>       Use a chapter definition file:
+                                   • .cue / .qcue  → CUE sheet
+                                   • .meta / .ffmetadata → FFmpeg chapter file
+                                   • anything else → plain text chapters (one "HH:MM:SS Title" per line)
+
+    Text chapter file format:
+      00:00:00 Track 1 Title
+      00:03:45 - Track 2 Title
+      [00:07:30] Track 3 Title
+
+    FFmpeg chapter file format:
+      ;FFMETADATA1
+      CHAPTER0000=00:00:00.000
+      CHAPTER0000NAME=Track 1 Title
+      CHAPTER0001=00:03:45.000
+      CHAPTER0001NAME=Track 2 Title
+
+    Output format options:
       --output-format <fmt>  Output format. Omit to keep original format (passthrough).
-                             Valid formats: flac, mp3, wav, aiff, alac, m4a, aac, ogg, opus
-
-    Format notes:
-      • Passthrough (default): no re-encoding, fastest, preserves original quality.
-      • FLAC: lossless, widely supported, larger files.
-      • MP3: universally compatible, smaller files, lossy.
-      • WAV: uncompressed, large files, universal support.
-      • AIFF: uncompressed, Apple ecosystem.
-      • ALAC / M4A / AAC: Apple lossless or lossy, efficient.
-      • OGG / Opus: open formats, efficient.
+                              Valid: flac, mp3, wav, aiff, alac, m4a, aac, ogg, opus
 
     Metadata & cover art:
       Passthrough preserves all metadata. When re-encoding, some formats have
@@ -154,7 +232,8 @@ struct TrackSplitterCLI {
 
     Examples:
       tracksplitter "/Users/music/陈升-别让我哭.flac"
-      tracksplitter "/Users/music/album.mp3"
+      tracksplitter "/Users/music/album.flac" --chapter-source embedded
+      tracksplitter "/Users/music/album.flac" --chapter-file chapters.txt
       tracksplitter "/Users/music/album.wav" --output-format flac
 
     Requirements:

--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -17,61 +17,62 @@ struct TrackSplitterCLI {
         }
 
         // Parse --chapter-source
+        // Parse chapter source options.
+        // --chapter-source and --chapter-file are mutually exclusive.
+        // Each parses from already-filtered args so consumed options don't reappear.
         var chapterSourceArg: String?
+        var chapterFileArg: String?
         var filteredArgs = args
-        if let idx = args.firstIndex(of: "--chapter-source") {
-            guard idx + 1 < args.count else {
+
+        // --chapter-source
+        if let idx = filteredArgs.firstIndex(of: "--chapter-source") {
+            guard idx + 1 < filteredArgs.count else {
                 print("Error: --chapter-source requires a value (e.g. --chapter-source embedded)")
                 exit(1)
             }
-            chapterSourceArg = args[idx + 1]
-            var copy = args
-            copy.remove(at: idx + 1)
-            copy.remove(at: idx)
-            filteredArgs = copy
-        } else if let idx = args.firstIndex(where: { $0.hasPrefix("--chapter-source=") }) {
-            chapterSourceArg = String(args[idx].dropFirst("--chapter-source=".count))
-            var copy = args
-            copy.remove(at: idx)
-            filteredArgs = copy
+            chapterSourceArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        } else if let idx = filteredArgs.firstIndex(where: { $0.hasPrefix("--chapter-source=") }) {
+            chapterSourceArg = String(filteredArgs[idx].dropFirst("--chapter-source=".count))
+            filteredArgs.remove(at: idx)
         }
 
-        // Parse --chapter-file (alias for --chapter-source with explicit file path)
-        var chapterFileArg: String?
-        if let idx = args.firstIndex(of: "--chapter-file") {
-            guard idx + 1 < args.count else {
+        // --chapter-file (mutually exclusive with --chapter-source)
+        if let idx = filteredArgs.firstIndex(of: "--chapter-file") {
+            if chapterSourceArg != nil {
+                print("Error: --chapter-source and --chapter-file are mutually exclusive.")
+                exit(1)
+            }
+            guard idx + 1 < filteredArgs.count else {
                 print("Error: --chapter-file requires a path (e.g. --chapter-file /path/to/chapters.txt)")
                 exit(1)
             }
-            chapterFileArg = args[idx + 1]
-            var copy = args
-            copy.remove(at: idx + 1)
-            copy.remove(at: idx)
-            filteredArgs = copy
-        } else if let idx = args.firstIndex(where: { $0.hasPrefix("--chapter-file=") }) {
-            chapterFileArg = String(args[idx].dropFirst("--chapter-file=".count))
-            var copy = args
-            copy.remove(at: idx)
-            filteredArgs = copy
+            chapterFileArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        } else if let idx = filteredArgs.firstIndex(where: { $0.hasPrefix("--chapter-file=") }) {
+            if chapterSourceArg != nil {
+                print("Error: --chapter-source and --chapter-file are mutually exclusive.")
+                exit(1)
+            }
+            chapterFileArg = String(filteredArgs[idx].dropFirst("--chapter-file=".count))
+            filteredArgs.remove(at: idx)
         }
 
-        // Parse --output-format
+        // --output-format (always parsed from already-filtered list)
         var outputFormatArg: String?
-        if let idx = args.firstIndex(of: "--output-format") {
-            guard idx + 1 < args.count else {
+        if let idx = filteredArgs.firstIndex(of: "--output-format") {
+            guard idx + 1 < filteredArgs.count else {
                 print("Error: --output-format requires a value (e.g. --output-format mp3)")
                 exit(1)
             }
-            outputFormatArg = args[idx + 1]
-            var copy = args
-            copy.remove(at: idx + 1)
-            copy.remove(at: idx)
-            filteredArgs = copy
-        } else if let idx = args.firstIndex(where: { $0.hasPrefix("--output-format=") }) {
-            outputFormatArg = String(args[idx].dropFirst("--output-format=".count))
-            var copy = args
-            copy.remove(at: idx)
-            filteredArgs = copy
+            outputFormatArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        } else if let idx = filteredArgs.firstIndex(where: { $0.hasPrefix("--output-format=") }) {
+            outputFormatArg = String(filteredArgs[idx].dropFirst("--output-format=".count))
+            filteredArgs.remove(at: idx)
         }
 
         // Validate output format early
@@ -203,8 +204,9 @@ struct TrackSplitterCLI {
       tracksplitter <file> --output-format mp3      Re-encode output to MP3
 
     Chapter source options:
+      --chapter-source auto       Auto-detect CUE in the same directory (default)
       --chapter-source embedded   Read chapters from the input audio file (if any)
-      --chapter-source cue        Explicitly use CUE auto-detection (default)
+      --chapter-source cue        Explicit CUE sheet (via file picker)
       --chapter-file <path>       Use a chapter definition file:
                                    • .cue / .qcue  → CUE sheet
                                    • .meta / .ffmetadata → FFmpeg chapter file

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -71,6 +71,47 @@ public enum AudioSplitterOutputFormat: String, CaseIterable, Identifiable {
     }
 }
 
+/// Chapter source type for the split (GUI-facing enum).
+/// Maps to ChapterSource in the engine but decoupled for UI flexibility.
+public enum ChapterSourceType: String, CaseIterable, Identifiable {
+    case auto = "auto"
+    case cue = "cue"
+    case textChapters = "text"
+    case ffmpegChapters = "ffmpeg"
+    case embedded = "embedded"
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .auto:    return "自动检测 CUE"
+        case .cue:     return "CUE 文件..."
+        case .textChapters:  return "文本章节..."
+        case .ffmpegChapters: return "FFmpeg 章节..."
+        case .embedded:      return "嵌入章节（从音频文件读取）"
+        }
+    }
+
+    /// Whether this type requires the user to pick a file via NSOpenPanel.
+    var requiresFile: Bool {
+        switch self {
+        case .auto, .embedded: return false
+        case .cue, .textChapters, .ffmpegChapters: return true
+        }
+    }
+
+    /// Build a ChapterSource for engine call, given the audio file URL and a chosen file URL.
+    func buildChapterSource(audioURL: URL, fileURL: URL?) -> ChapterSource? {
+        switch self {
+        case .auto:    return nil
+        case .embedded: return .embedded(audioURL)
+        case .cue:     guard let u = fileURL else { return nil }; return .cue(u)
+        case .textChapters:  guard let u = fileURL else { return nil }; return .textChapters(u)
+        case .ffmpegChapters: guard let u = fileURL else { return nil }; return .ffmpegChapters(u)
+        }
+    }
+}
+
 /// 负责协调界面与核心引擎的视图模型。
 /// 直接持有所有 @Published 状态，不通过中间 AppState，避免跨对象观察链失效。
 @MainActor
@@ -161,6 +202,12 @@ else:
     /// Selected output format for the split. nil = same as input.
     @Published var selectedOutputFormat: AudioSplitterOutputFormat = .keepOriginal
 
+    /// Selected chapter source type for the split.
+    @Published var selectedChapterSourceType: ChapterSourceType = .auto
+
+    /// Resolved chapter source URL (set when user picks a file via NSOpenPanel).
+    @Published var chapterSourceURL: URL? = nil
+
     /// The currently running engine, if any. Used to support cancellation.
     private var activeEngine: TrackSplitterEngine?
 
@@ -222,8 +269,13 @@ else:
         Task {
             let engine = TrackSplitterEngine(logHandler: handler)
             self.activeEngine = engine
+            let chapterSource = selectedChapterSourceType.buildChapterSource(
+                audioURL: loaded.audioURL,
+                fileURL: chapterSourceURL
+            )
             let outcome = await engine.process(inputURL: loaded.audioURL,
-                                               outputFormat: selectedOutputFormat.audioFormat)
+                                               outputFormat: selectedOutputFormat.audioFormat,
+                                               chapterSource: chapterSource)
 
             await MainActor.run {
                 self.progress = 1

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -14,6 +14,8 @@ struct ContentView: View {
             case .idle:
                 IdleView(onFileSelected: { url in
                     viewModel.selectedOutputFormat = .keepOriginal
+                    viewModel.selectedChapterSourceType = .auto
+                    viewModel.chapterSourceURL = nil
                     viewModel.load(audioURL: url)
                 })
 
@@ -21,7 +23,9 @@ struct ContentView: View {
                 LoadedView(
                     loaded: loaded,
                     onStart: { viewModel.startProcessing() },
-                    selectedOutputFormat: $viewModel.selectedOutputFormat
+                    selectedOutputFormat: $viewModel.selectedOutputFormat,
+                    selectedChapterSourceType: $viewModel.selectedChapterSourceType,
+                    chapterSourceURL: $viewModel.chapterSourceURL
                 )
 
             case .processing:
@@ -42,6 +46,8 @@ struct ContentView: View {
                     },
                     onProcessAnother: {
                         viewModel.selectedOutputFormat = .keepOriginal
+                        viewModel.selectedChapterSourceType = .auto
+                        viewModel.chapterSourceURL = nil
                         viewModel.processAnother()
                     }
                 )
@@ -284,6 +290,10 @@ struct LoadedView: View {
     let loaded: SplitterViewModel.LoadedFiles
     let onStart: () -> Void
     @Binding var selectedOutputFormat: AudioSplitterOutputFormat
+    @Binding var selectedChapterSourceType: ChapterSourceType
+    @Binding var chapterSourceURL: URL?
+
+
 
     var body: some View {
         VStack(spacing: 0) {
@@ -324,10 +334,32 @@ struct LoadedView: View {
             Divider()
 
             HStack {
-                Text("CUE: \(loaded.cueURL.lastPathComponent)")
+                Text("分割依据：")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
+
+                Picker("", selection: $selectedChapterSourceType) {
+                    ForEach(ChapterSourceType.allCases) { type in
+                        Text(type.displayName).tag(type)
+                    }
+                }
+                .frame(width: 260)
+
+                // Show chosen file name for types that require a file
+                if selectedChapterSourceType.requiresFile {
+                    if let url = chapterSourceURL {
+                        Text(url.lastPathComponent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .frame(maxWidth: 160)
+                    } else {
+                        Text("（未选择文件）")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
 
                 Spacer()
 
@@ -370,6 +402,40 @@ struct LoadedView: View {
             .background(Color(nsColor: .controlBackgroundColor))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onChange(of: selectedChapterSourceType) { newValue in
+            if !newValue.requiresFile {
+                // Switching to auto or embedded — clear any previously picked file
+                chapterSourceURL = nil
+                return
+            }
+
+            // newValue requires a file — show NSOpenPanel
+            let panel = NSOpenPanel()
+            panel.allowsMultipleSelection = false
+            panel.canChooseDirectories = false
+
+            switch newValue {
+            case .cue:
+                panel.allowedContentTypes = [UTType(filenameExtension: "cue")!, UTType(filenameExtension: "qcue")!]
+                panel.message = "选择 CUE 文件"
+            case .textChapters:
+                panel.allowedContentTypes = [.text, .plainText]
+                panel.message = "选择文本章节文件"
+            case .ffmpegChapters:
+                panel.allowedContentTypes = [UTType(filenameExtension: "meta")!, UTType(filenameExtension: "ffmetadata")!]
+                panel.message = "选择 FFmpeg 章节文件"
+            default:
+                break
+            }
+
+            if panel.runModal() == .OK, let url = panel.url {
+                chapterSourceURL = url
+            } else {
+                // User cancelled the panel — revert picker to auto (no file selected)
+                selectedChapterSourceType = .auto
+                chapterSourceURL = nil
+            }
+        }
     }
 }
 

--- a/Library/ChapterSource.swift
+++ b/Library/ChapterSource.swift
@@ -1,0 +1,386 @@
+import Foundation
+
+/// Represents a source of chapter/track definitions for splitting.
+/// Each case carries the URL of the source file plus any parsed metadata.
+public enum ChapterSource: Sendable {
+    /// Standard CUE sheet (existing path).
+    case cue(URL)
+    /// Plain text chapter file with one timestamp+title per line.
+    case textChapters(URL)
+    /// FFmpeg chapter metadata file (INI-style with CHAPTER blocks).
+    case ffmpegChapters(URL)
+    /// Chapters embedded in the audio file itself (read via ffprobe).
+    case embedded(URL)
+}
+
+extension ChapterSource {
+    /// Human-readable description of this source type.
+    public var typeName: String {
+        switch self {
+        case .cue: return "CUE"
+        case .textChapters: return "Text chapters"
+        case .ffmpegChapters: return "FFmpeg chapters"
+        case .embedded: return "Embedded chapters"
+        }
+    }
+
+    /// The file URL this source points to.
+    public var url: URL {
+        switch self {
+        case .cue(let u), .textChapters(let u),
+             .ffmpegChapters(let u), .embedded(let u):
+            return u
+        }
+    }
+}
+
+// MARK: - Text Chapter Parser
+
+/// Parses plain text chapter files with timestamped lines.
+///
+/// Supported line formats (one track per line):
+///   00:00:00 Track 1 Title
+///   00:00:00 - Track 2 Title
+///   [00:00:00] Track 3 Title
+///   00:00:00.500 Track 4 Title  (sub-second precision)
+public struct TextChapterParser: Sendable {
+
+    public enum Error: Swift.Error, LocalizedError {
+        case fileNotFound(URL)
+        case emptyFile(URL)
+        case noValidTimestamps(URL)
+        case invalidTimestamp(line: String, index: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .fileNotFound(let url):
+                return "Chapter file not found: \(url.lastPathComponent)"
+            case .emptyFile(let url):
+                return "Chapter file is empty: \(url.lastPathComponent)"
+            case .noValidTimestamps(let url):
+                return "No valid timestamps found in: \(url.lastPathComponent)"
+            case .invalidTimestamp(let line, let index):
+                return "Invalid timestamp on line \(index + 1): '\(line)'"
+            }
+        }
+    }
+
+    public init() {}
+
+    /// Parse a text chapter file into an array of CueTrack-compatible entries.
+    /// - Parameters:
+    ///   - url: URL of the text chapter file
+    ///   - defaultTitle: Title to use for tracks that have no title in the file
+    /// - Returns: Array of (startSeconds, title) tuples in order
+    public func parse(at url: URL, defaultTitle: String = "Track") throws -> [(startSeconds: Double, title: String)] {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw Error.fileNotFound(url)
+        }
+
+        let content: String
+        do {
+            content = try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            // Try Big5 and DOS Latin 1 as fallback encodings
+            // swiftlint:disable legacy_objc_type
+            if let big5 = try? String(contentsOf: url, encoding: .init(rawValue: UInt(CFStringEncodings.big5.rawValue))) {
+                content = big5
+            } else if let latin1 = try? String(contentsOf: url, encoding: .init(rawValue: UInt(CFStringEncodings.dosLatin1.rawValue))) {
+                content = latin1
+            } else {
+                // Last resort — try latin1 without caring about errors
+                content = (try? String(contentsOf: url, encoding: .isoLatin1)) ?? ""
+            }
+        }
+
+        let lines = content.components(separatedBy: .newlines)
+        var entries: [(startSeconds: Double, title: String)] = []
+        var lineIndex = 0
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty { continue }
+            if trimmed.hasPrefix("#") || trimmed.hasPrefix("//") { continue }
+
+            // Try various timestamp formats
+            if let (seconds, rest) = parseTimestampLine(trimmed) {
+                let title = extractTitle(rest, defaultTitle: defaultTitle, index: lineIndex)
+                entries.append((seconds, title))
+            }
+            lineIndex += 1
+        }
+
+        guard !entries.isEmpty else {
+            throw Error.noValidTimestamps(url)
+        }
+
+        // Sort by timestamp
+        entries.sort { $0.startSeconds < $1.startSeconds }
+        return entries
+    }
+
+    /// Parse a timestamp from a line and return the seconds value + remainder of line.
+    private func parseTimestampLine(_ line: String) -> (seconds: Double, rest: String)? {
+        // Supported formats:
+        //   00:00:00 Title
+        //   [00:00:00] Title
+        //   00:00:00.500 Title
+        var work = line.trimmingCharacters(in: .whitespaces)
+
+        var rest = ""
+
+        // Strip matched [ ... ] pair and preserve anything after the closing ]
+        if work.hasPrefix("[") {
+            if let endBracket = work.firstIndex(of: "]") {
+                // textAfter = everything after the closing ]
+                let afterBracket = work.index(after: endBracket)
+                rest = String(work[afterBracket...]).trimmingCharacters(in: .whitespaces)
+                // work = content inside brackets
+                work = String(work[work.index(after: work.startIndex)..<endBracket])
+            }
+        }
+
+        // Extract timestamp (first token, before first space)
+        let parts = work.split(separator: " ", maxSplits: 1)
+        guard let first = parts.first else { return nil }
+        let tsString = String(first)
+
+        // Parse H:M:S[.f]
+        let tsComponents = tsString.split(separator: ":")
+        guard tsComponents.count == 2 || tsComponents.count == 3 else { return nil }
+
+        guard let hours = Double(tsComponents[0]),
+              let minutes = Double(tsComponents[1]) else { return nil }
+
+        var totalSeconds: Double = minutes * 60 + hours * 3600
+
+        if tsComponents.count == 3 {
+            guard let sec = Double(tsComponents[2]) else { return nil }
+            totalSeconds += sec
+        }
+
+        // If no rest was extracted from the [bracket] form, use the remainder from work.split
+        if rest.isEmpty && parts.count > 1 {
+            rest = String(parts[1])
+        }
+
+        return (totalSeconds, rest)
+    }
+
+    /// Extract a clean title from the remainder of the line.
+    private func extractTitle(_ rest: String, defaultTitle: String, index: Int) -> String {
+        var title = rest.trimmingCharacters(in: .whitespaces)
+
+        // Strip leading "- " or ": " separator
+        if title.hasPrefix("- ") { title = String(title.dropFirst(2)) }
+        if title.hasPrefix(": ")  { title = String(title.dropFirst(2)) }
+
+        title = title.trimmingCharacters(in: .whitespaces)
+
+        if title.isEmpty {
+            return "\(defaultTitle) \(index + 1)"
+        }
+        return title
+    }
+}
+
+// MARK: - FFmpeg Chapter Parser
+
+/// Parses FFmpeg chapter metadata files (INI-style with CHAPTER BEGIN/END/TITLE).
+public struct FFmpegChapterParser: Sendable {
+
+    public enum Error: Swift.Error, LocalizedError {
+        case fileNotFound(URL)
+        case emptyFile(URL)
+        case noValidChapters(URL)
+
+        public var errorDescription: String? {
+            switch self {
+            case .fileNotFound(let url): return "Chapter file not found: \(url.lastPathComponent)"
+            case .emptyFile(let url):    return "Chapter file is empty: \(url.lastPathComponent)"
+            case .noValidChapters(let url): return "No valid chapters found in: \(url.lastPathComponent)"
+            }
+        }
+    }
+
+    public init() {}
+
+    /// Parse an FFmpeg chapter metadata file.
+    /// Format:
+    ///   ;FFMETADATA1
+    ///   title=Album Title
+    ///   artist=Artist
+    ///   CHAPTER0000=00:00:00.000
+    ///   CHAPTER0000NAME=Track 1
+    ///   CHAPTER0001=00:03:45.000
+    ///   CHAPTER0001NAME=Track 2
+    public func parse(at url: URL) throws -> [(startSeconds: Double, title: String)] {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw Error.fileNotFound(url)
+        }
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        guard !content.isEmpty else { throw Error.emptyFile(url) }
+
+        var chapters: [(startSeconds: Double, title: String)] = []
+
+        // Match CHAPTERXXXX=HH:MM:SS.mmm
+        let chapterPattern = #"CHAPTER\d+=\s*(\d+):(\d{2}):(\d{2})\.(\d+)"#
+        let namePattern  = #"CHAPTER\d+NAME=\s*(.+)"#
+
+        let chapterRegex = try! NSRegularExpression(pattern: chapterPattern, options: [])
+        let nameRegex    = try! NSRegularExpression(pattern: namePattern,  options: [])
+
+        let lines = content.components(separatedBy: .newlines)
+
+        var currentChapter: (startSeconds: Double, title: String)?
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix(";") { continue }
+
+            // Check for CHAPTER timestamp line
+            let range = NSRange(trimmed.startIndex..., in: trimmed)
+            if let match = chapterRegex.firstMatch(in: trimmed, options: [], range: range) {
+                // Flush previous chapter
+                if let ch = currentChapter {
+                    chapters.append(ch)
+                }
+
+                // Parse HH:MM:SS.mmm
+                let h  = Double(trimmed[( Range(match.range(at: 1), in: trimmed) )!])!
+                let m  = Double(trimmed[( Range(match.range(at: 2), in: trimmed) )!])!
+                let s  = Double(trimmed[( Range(match.range(at: 3), in: trimmed) )!])!
+                let ms = Double(trimmed[( Range(match.range(at: 4), in: trimmed) )!])! / 1000.0
+
+                let seconds = h * 3600 + m * 60 + s + ms
+                currentChapter = (seconds, "Chapter \(chapters.count + 1)")
+            }
+
+            // Check for CHAPTER NAME line
+            if let match = nameRegex.firstMatch(in: trimmed, options: [], range: range),
+               let nameRange = Range(match.range(at: 1), in: trimmed) {
+                var title = String(trimmed[nameRange]).trimmingCharacters(in: .whitespaces)
+                if !title.isEmpty, var ch = currentChapter {
+                    ch.title = title
+                    currentChapter = ch
+                }
+            }
+        }
+
+        // Flush last chapter
+        if let ch = currentChapter {
+            chapters.append(ch)
+        }
+
+        guard !chapters.isEmpty else { throw Error.noValidChapters(url) }
+
+        chapters.sort { $0.startSeconds < $1.startSeconds }
+        return chapters
+    }
+}
+
+// MARK: - Embedded Chapter Reader
+
+/// Reads embedded chapter markers from an audio file using ffprobe.
+public struct EmbeddedChapterReader: Sendable {
+
+    public enum Error: Swift.Error, LocalizedError {
+        case ffprobeNotFound
+        case noChaptersFound(URL)
+        case parseError(URL, String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .ffprobeNotFound:
+                return "ffprobe not found — cannot read embedded chapters"
+            case .noChaptersFound(let url):
+                return "No embedded chapters found in: \(url.lastPathComponent)"
+            case .parseError(let url, let detail):
+                return "Failed to parse chapters from \(url.lastPathComponent): \(detail)"
+            }
+        }
+    }
+
+    public init() {}
+
+    /// Read embedded chapters from an audio file using ffprobe.
+    /// Returns an array of (startSeconds, title) tuples.
+    public func read(from url: URL) async throws -> [(startSeconds: Double, title: String)] {
+        let ffprobePath = try Self.ffprobePath()
+
+        let args = [
+            "-v", "quiet",
+            "-print_format", "json",
+            "-show_chapters",
+            url.path
+        ]
+
+        let output = try await runProcess(executable: ffprobePath, arguments: args)
+
+        return try parseFfprobeJSON(output, url: url)
+    }
+
+    private func parseFfprobeJSON(_ json: String, url: URL) throws -> [(startSeconds: Double, title: String)] {
+        guard let data = json.data(using: .utf8) else {
+            throw Error.parseError(url, "invalid UTF-8 in ffprobe output")
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let chapters = json["chapters"] as? [[String: Any]] else {
+            throw Error.noChaptersFound(url)
+        }
+
+        var entries: [(startSeconds: Double, title: String)] = []
+
+        for (index, ch) in chapters.enumerated() {
+            guard let startMs = ch["start_time"] as? String,
+                  let endMs   = ch["end_time"]   as? String,
+                  let start    = Double(startMs),
+                  let end      = Double(endMs) else { continue }
+
+            var title = "Chapter \(index + 1)"
+            if let tags = ch["tags"] as? [String: Any],
+               let t = tags["title"] as? String, !t.isEmpty {
+                title = t
+            }
+
+            entries.append((startSeconds: start, title: title))
+        }
+
+        guard !entries.isEmpty else { throw Error.noChaptersFound(url) }
+        entries.sort { $0.startSeconds < $1.startSeconds }
+        return entries
+    }
+
+    private static func ffprobePath() throws -> String {
+        let candidates = ["/opt/homebrew/bin/ffprobe", "/usr/local/bin/ffprobe", "/usr/bin/ffprobe", "ffprobe"]
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        // Last resort — let shell resolve
+        return "ffprobe"
+    }
+
+    private func runProcess(executable: String, arguments: [String]) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: executable)
+            proc.arguments = arguments
+            let pipe = Pipe()
+            proc.standardOutput = pipe
+            proc.standardError = FileHandle.nullDevice
+            do {
+                try proc.run()
+                proc.waitUntilExit()
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8) ?? ""
+                continuation.resume(returning: output)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -191,28 +191,95 @@ public actor TrackSplitterEngine {
     ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
     ///     `.flac` = re-encode to FLAC (lossless, smaller file).
     ///     `.wav` = re-encode to WAV (lossless PCM, larger file).
-    public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async -> EngineOutcome {
+    public func process(
+        inputURL: URL,
+        outputFormat: AudioSplitter.AudioFormat? = nil,
+        chapterSource: ChapterSource? = nil
+    ) async -> EngineOutcome {
         _isCancelled = false  // Reset cancellation for each new process run
         log("📂 Input: \(inputURL.lastPathComponent)")
 
-        // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
-        guard let cueURL = findCue(for: inputURL) else {
+        // ─── Resolve chapter source ───────────────────────────────────────────────
+        typealias ChapterResult = ([CueTrack], String?, String?, CueFile?, CueRem, String)
+
+        func resolve(source: ChapterSource?) async throws -> ChapterResult {
+            if let src = source {
+                switch src {
+                case .cue(let url):
+                    log("📋 Chapter source: CUE (\(url.lastPathComponent))")
+                    let (t, at, p, cf, cr) = try parseCue(at: url)
+                    return (t, at, p, cf, cr, "CUE")
+
+                case .textChapters(let url):
+                    log("📋 Chapter source: text chapters (\(url.lastPathComponent))")
+                    let entries = try TextChapterParser().parse(at: url)
+                    let t = entries.enumerated().map { i, e in
+                        CueTrack(index: i + 1, title: e.title,
+                                  startSeconds: e.startSeconds, endSeconds: nil)
+                    }
+                    return (t, nil, nil, nil, CueRem(), "text chapters")
+
+                case .ffmpegChapters(let url):
+                    log("📋 Chapter source: FFmpeg chapters (\(url.lastPathComponent))")
+                    let entries = try FFmpegChapterParser().parse(at: url)
+                    let t = entries.enumerated().map { i, e in
+                        CueTrack(index: i + 1, title: e.title,
+                                  startSeconds: e.startSeconds, endSeconds: nil)
+                    }
+                    return (t, nil, nil, nil, CueRem(), "FFmpeg chapters")
+
+                case .embedded(let url):
+                    log("📋 Chapter source: embedded (\(url.lastPathComponent))")
+                    let entries = try await EmbeddedChapterReader().read(from: url)
+                    let t = entries.enumerated().map { i, e in
+                        CueTrack(index: i + 1, title: e.title,
+                                  startSeconds: e.startSeconds, endSeconds: nil)
+                    }
+                    return (t, nil, nil, nil, CueRem(), "embedded")
+                }
+            }
+
+            // No source provided: auto-detect CUE
+            guard let cueURL = findCue(for: inputURL) else {
+                return ([], nil, nil, nil, CueRem(), "none")
+            }
+            log("📋 Chapter source: auto-detected CUE (\(cueURL.lastPathComponent))")
+            let (t, at, p, cf, cr) = try parseCue(at: cueURL)
+            return (t, at, p, cf, cr, "CUE")
+        }
+
+        // ─── Execute resolve and handle result ────────────────────────────────────
+        var tracks: [CueTrack]          = []
+        var albumTitle: String?           = nil
+        var performer: String?            = nil
+        var cueFile: CueFile?             = nil
+        var cueRem: CueRem                = CueRem()
+        var sourceLabel: String           = "unknown"
+
+        let result: ChapterResult
+        do {
+            result = try await resolve(source: chapterSource)
+        } catch {
+            return .failure(message: "Chapter parse error: \(error.localizedDescription)")
+        }
+        (tracks, albumTitle, performer, cueFile, cueRem, sourceLabel) = result
+
+        if sourceLabel == "none" && tracks.isEmpty {
             return .failure(message: EngineError.noCueFile(inputURL).localizedDescription)
         }
-        log("📋 CUE found: \(cueURL.lastPathComponent)")
 
-        // 2. Parse CUE (handles Chinese encodings via Big5/CP950 detection)
-        let (tracks, albumTitle, performer, cueFile, cueRem): ([CueTrack], String?, String?, CueFile?, CueRem)
-        do {
-            (tracks, albumTitle, performer, cueFile, cueRem) = try parseCue(at: cueURL)
-        } catch {
-            return .failure(message: "CUE parse error: \(error.localizedDescription)")
+        guard !tracks.isEmpty else {
+            return .failure(message: EngineError.emptyTracks.localizedDescription)
         }
-        log("🎵 Tracks: \(tracks.count) | Album: \(albumTitle ?? "—") | Artist: \(performer ?? "—")")
-        log("📋 REM: date=\(cueRem.date ?? "—") genre=\(cueRem.genre ?? "—") comment=\(cueRem.comment ?? "—") composer=\(cueRem.composer ?? "—") discNumber=\(cueRem.discNumber ?? "—")")
 
-        // 2b. Validate FILE field if present — use fuzzy match to handle encoding mismatches
-        if let cf = cueFile {
+        log("🎵 Tracks: \(tracks.count) | Source: \(sourceLabel)")
+        if sourceLabel == "CUE" {
+            log("🎵 Album: \(albumTitle ?? "—") | Artist: \(performer ?? "—")")
+            log("📋 REM: date=\(cueRem.date ?? "—") genre=\(cueRem.genre ?? "—") comment=\(cueRem.comment ?? "—") composer=\(cueRem.composer ?? "—") discNumber=\(cueRem.discNumber ?? "—")")
+        }
+
+        // Cue FILE field validation (CUE path only)
+        if sourceLabel == "CUE", let cf = cueFile {
             let cueDeclaredName = cf.resolvedURL.lastPathComponent
             let similarity = stringSimilarity(cueDeclaredName, inputURL.lastPathComponent)
             if similarity < 0.80 {
@@ -224,11 +291,7 @@ public actor TrackSplitterEngine {
             }
         }
 
-        guard !tracks.isEmpty else {
-            return .failure(message: EngineError.emptyTracks.localizedDescription)
-        }
-
-        // 2. Pre-flight environment check — after input validation, before any file system operations
+        // 2. Pre-flight environment check// 2. Pre-flight environment check — after input validation, before any file system operations// 2. Pre-flight environment check — after input validation, before any file system operations
         let envReport = await embedder.checkEnvironment()
         if !envReport.isHealthy {
             let issues = envReport.issues

--- a/Tests/ChapterSourceTests.swift
+++ b/Tests/ChapterSourceTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+@testable import TrackSplitterLib
+import XCTest
+
+final class ChapterSourceTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tracksplitter_chapter_test_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try await super.tearDown()
+    }
+
+    // MARK: - TextChapterParser
+
+    func testTextChapterParser_basicFormat() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try """
+        00:00:00 Track 1
+        00:03:45 Track 2
+        00:07:30 Track 3
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 3)
+        XCTAssertEqual(entries[0].title, "Track 1")
+        XCTAssertEqual(entries[0].startSeconds, 0)
+        XCTAssertEqual(entries[1].title, "Track 2")
+        XCTAssertEqual(entries[1].startSeconds, 225)
+        XCTAssertEqual(entries[2].title, "Track 3")
+        XCTAssertEqual(entries[2].startSeconds, 450)
+    }
+
+    func testTextChapterParser_dashSeparator() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try """
+        00:00:00 - Opening
+        00:02:30 - Main Track
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries[0].title, "Opening")
+        XCTAssertEqual(entries[1].title, "Main Track")
+    }
+
+    func testTextChapterParser_bracketsFormat() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try """
+        [00:00:00] First
+        [00:05:00] Second
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].title, "First")
+        XCTAssertEqual(entries[0].startSeconds, 0)
+        XCTAssertEqual(entries[1].startSeconds, 300)
+    }
+
+    func testTextChapterParser_withSubseconds() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try "00:00:00.500 First Track\n00:01:00.000 Second Track\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries[0].startSeconds, 0.5, accuracy: 0.001)
+        XCTAssertEqual(entries[1].startSeconds, 60.0, accuracy: 0.001)
+    }
+
+    func testTextChapterParser_commentsSkipped() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try """
+        # This is a comment
+        00:00:00 Track 1
+        // Another comment
+        00:02:00 Track 2
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].title, "Track 1")
+        XCTAssertEqual(entries[1].title, "Track 2")
+    }
+
+    func testTextChapterParser_emptyLinesSkipped() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try "\n\n00:00:00 Track 1\n\n\n00:02:00 Track 2\n\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 2)
+    }
+
+    func testTextChapterParser_missingTitle() throws {
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        // Title-only line with no text after timestamp → default title used
+        try "00:00:00\n00:03:00\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file, defaultTitle: "Track")
+
+        XCTAssertEqual(entries[0].title, "Track 1")
+        XCTAssertEqual(entries[1].title, "Track 2")
+    }
+
+    func testTextChapterParser_unsortedEntries() throws {
+        // Parser should sort by timestamp even if file is out of order
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try """
+        00:05:00 Track 3
+        00:00:00 Track 1
+        00:02:30 Track 2
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries[0].startSeconds, 0)
+        XCTAssertEqual(entries[1].startSeconds, 150)
+        XCTAssertEqual(entries[2].startSeconds, 300)
+    }
+
+    func testTextChapterParser_fileNotFound() throws {
+        let file = tempDir.appendingPathComponent("nonexistent.txt")
+        let parser = TextChapterParser()
+        do {
+            _ = try parser.parse(at: file)
+            XCTFail("Expected Error.fileNotFound")
+        } catch let error as TextChapterParser.Error {
+            if case .fileNotFound = error { /* expected */ } else { XCTFail("Wrong error type: \(error)") }
+        }
+    }
+
+    func testTextChapterParser_noValidTimestamps() throws {
+        let file = tempDir.appendingPathComponent("no_ts.txt")
+        try "This file has no timestamps\nJust plain text".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        do {
+            _ = try parser.parse(at: file)
+            XCTFail("Expected Error.noValidTimestamps")
+        } catch let error as TextChapterParser.Error {
+            if case .noValidTimestamps = error { /* expected */ } else { XCTFail("Wrong error type: \(error)") }
+        }
+    }
+
+    // MARK: - FFmpegChapterParser
+
+    func testFFmpegChapterParser_basic() throws {
+        let file = tempDir.appendingPathComponent("chapters.meta")
+        try """
+        ;FFMETADATA1
+        title=Album Title
+        artist=Album Artist
+        CHAPTER0000=00:00:00.000
+        CHAPTER0000NAME=First Track
+        CHAPTER0001=00:03:45.000
+        CHAPTER0001NAME=Second Track
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = FFmpegChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries[0].title, "First Track")
+        XCTAssertEqual(entries[0].startSeconds, 0)
+        XCTAssertEqual(entries[1].title, "Second Track")
+        XCTAssertEqual(entries[1].startSeconds, 225)
+    }
+
+    func testFFmpegChapterParser_noTimestampTitle() throws {
+        let file = tempDir.appendingPathComponent("chapters.meta")
+        try """
+        ;FFMETADATA1
+        CHAPTER0000=00:00:00.000
+        CHAPTER0000NAME=
+        CHAPTER0001=00:02:00.000
+        CHAPTER0001NAME=Named Track
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = FFmpegChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries[0].title, "Chapter 1")   // empty name → default
+        XCTAssertEqual(entries[1].title, "Named Track")
+    }
+
+    func testFFmpegChapterParser_fileNotFound() throws {
+        let file = tempDir.appendingPathComponent("nonexistent.meta")
+        let parser = FFmpegChapterParser()
+        do {
+            _ = try parser.parse(at: file)
+            XCTFail("Expected Error.fileNotFound")
+        } catch let error as FFmpegChapterParser.Error {
+            if case .fileNotFound = error { /* expected */ } else { XCTFail("Wrong error: \(error)") }
+        }
+    }
+
+    // MARK: - ChapterSource
+
+    func testChapterSource_typeName() {
+        XCTAssertEqual(ChapterSource.cue(URL(fileURLWithPath: "/a")).typeName, "CUE")
+        XCTAssertEqual(ChapterSource.textChapters(URL(fileURLWithPath: "/a")).typeName, "Text chapters")
+        XCTAssertEqual(ChapterSource.ffmpegChapters(URL(fileURLWithPath: "/a")).typeName, "FFmpeg chapters")
+        XCTAssertEqual(ChapterSource.embedded(URL(fileURLWithPath: "/a")).typeName, "Embedded chapters")
+    }
+
+    func testChapterSource_url() {
+        let url = URL(fileURLWithPath: "/path/to/file.txt")
+        XCTAssertEqual(ChapterSource.cue(url).url, url)
+        XCTAssertEqual(ChapterSource.textChapters(url).url, url)
+        XCTAssertEqual(ChapterSource.ffmpegChapters(url).url, url)
+        XCTAssertEqual(ChapterSource.embedded(url).url, url)
+    }
+}


### PR DESCRIPTION
## Summary

Extends TrackSplitter to support chapter/split sources beyond CUE sheets:

- **Text chapter files**: plain text with one `HH:MM:SS Title` per line
- **FFmpeg chapter files**: `.meta` / `.ffmetadata` format
- **Embedded chapters**: read from the audio file itself via ffprobe

## New CLI options

```
--chapter-source embedded   Read chapters from the input audio file
--chapter-source cue        Explicit CUE (default)
--chapter-file <path>       Use a chapter definition file:
                             • .cue/.qcue → CUE sheet
                             • .meta/.ffmetadata → FFmpeg chapters
                             • anything else → plain text chapters
```

## Engine API

`process(inputURL:outputFormat:chapterSource:)` gains optional `chapterSource` parameter.

## Files changed

- `Library/ChapterSource.swift` — enum + 3 parser implementations
- `Library/TrackSplitterEngine.swift` — chapter source routing in `process()`
- `CLI/main.swift` — `--chapter-source` / `--chapter-file` CLI options
- `Tests/ChapterSourceTests.swift` — unit tests for all parsers

## Tests

`swift test` → **99 tests, 0 failures**