### PR TITLE
feat: 输出目录和文件名模板配置 (issue #3)

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -16,20 +16,113 @@ struct TrackSplitterCLI {
             return
         }
 
+        // Parse options from args (累积过滤模式)
+        var filteredArgs = args
+        var outputDirArg: String?
+        var nameTemplateArg: String?
+        var overwriteArg: String?
+        var outputFormatArg: String?
+
+        if let idx = filteredArgs.firstIndex(of: "--output-dir") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --output-dir requires a path argument.")
+                exit(1)
+            }
+            outputDirArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        }
+
+        if let idx = filteredArgs.firstIndex(of: "--name-template") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --name-template requires a template argument.")
+                exit(1)
+            }
+            nameTemplateArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        }
+
+        if let idx = filteredArgs.firstIndex(of: "--overwrite") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --overwrite requires a policy argument (rename|overwrite|skip).")
+                exit(1)
+            }
+            overwriteArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        }
+
+        if let idx = filteredArgs.firstIndex(of: "--output-format") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --output-format requires a format argument.")
+                exit(1)
+            }
+            outputFormatArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        }
+
+        // Validate overwrite policy
+        let overwritePolicy: AudioSplitter.OverwritePolicy
+        if let arg = overwriteArg {
+            switch arg.lowercased() {
+            case "rename": overwritePolicy = .rename
+            case "overwrite": overwritePolicy = .overwrite
+            case "skip": overwritePolicy = .skip
+            default:
+                print("Error: --overwrite must be one of: rename, overwrite, skip")
+                exit(1)
+            }
+        } else {
+            overwritePolicy = .rename
+        }
+
+        // Validate output format
+        let outputFormat: AudioSplitter.AudioFormat?
+        if let arg = outputFormatArg {
+            switch arg.lowercased() {
+            case "flac": outputFormat = .flac
+            case "mp3": outputFormat = .mp3
+            case "wav": outputFormat = .wav
+            case "alac": outputFormat = .alac
+            default:
+                print("Error: --output-format must be one of: flac, mp3, wav, alac")
+                exit(1)
+            }
+        } else {
+            outputFormat = nil
+        }
+
+        // Build OutputConfig
+        let outputConfig = TrackSplitterEngine.OutputConfig(
+            outputDirectory: outputDirArg.map { URL(fileURLWithPath: $0) },
+            nameTemplate: nameTemplateArg ?? "{index}. {title}.{ext}",
+            overwritePolicy: overwritePolicy
+        )
+
         // CLI mode: positional audio file path
-        let audioPath = args.first { !$0.hasPrefix("-") }
+        let audioPath = filteredArgs.first { !$0.hasPrefix("-") }
         guard let audioPath else {
             print("Error: No audio file specified. Pass a supported audio file path.")
             print("Run 'tracksplitter --help' for usage.")
             exit(1)
         }
 
-        runCLI(audioPath: audioPath)
+        runCLI(
+            audioPath: audioPath,
+            outputConfig: outputConfig,
+            outputFormat: outputFormat
+        )
     }
 
     // MARK: - CLI mode
 
-    private static func runCLI(audioPath: String) {
+    private static func runCLI(
+        audioPath: String,
+        outputConfig: TrackSplitterEngine.OutputConfig,
+        outputFormat: AudioSplitter.AudioFormat?
+    ) {
         let audioURL = URL(fileURLWithPath: audioPath)
 
         guard FileManager.default.fileExists(atPath: audioURL.path) else {
@@ -57,7 +150,11 @@ struct TrackSplitterCLI {
 
         Task {
             do {
-                let result = try await engine.process(inputURL: audioURL)
+                let result = try await engine.process(
+                    inputURL: audioURL,
+                    outputFormat: outputFormat,
+                    outputConfig: outputConfig
+                )
                 print("\n✅ Done! \(result.trackFiles.count) tracks saved to:")
                 print("   \(result.outputDirectory.path)")
             } catch {
@@ -69,7 +166,7 @@ struct TrackSplitterCLI {
 
         semaphore.wait()
 
-        if let err = runError {
+        if runError != nil {
             exit(1)
         }
     }
@@ -85,12 +182,20 @@ struct TrackSplitterCLI {
       tracksplitter <file>        Process an audio file from the command line
 
     Options:
-      --help, -h  Show this help
-      --version   Show version
+      --output-dir <path>    Output directory (default: same dir as input)
+      --name-template <tmpl> Filename template with placeholders:
+                             {index}, {title}, {artist}, {album}, {ext}
+                             Default: "{index}. {title}.{ext}"
+      --overwrite <policy>   rename | overwrite | skip  (default: rename)
+      --output-format <fmt>   flac | mp3 | wav | alac  (default: keep original)
+      --help, -h             Show this help
+      --version              Show version
 
     Examples:
       tracksplitter "/Users/music/陈升-别让我哭.flac"
-      tracksplitter "/Users/music/album.mp3"
+      tracksplitter "/Users/music/album.mp3" --output-dir ~/Desktop/tracks
+      tracksplitter "album.flac" --name-template "{index:02d} {title}.{ext}"
+      tracksplitter "album.flac" --overwrite skip
 
     Requirements:
       • ffmpeg    (brew install ffmpeg)

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -172,6 +172,12 @@ else:
     @Published var errorMessage: String = ""
     /// Selected output format for the split. nil = same as input.
     @Published var selectedOutputFormat: AudioSplitterOutputFormat = .keepOriginal
+    /// Custom output directory. nil = default (same dir as input).
+    @Published var customOutputDirectory: URL?
+    /// Filename template with placeholders: {index}, {title}, {artist}, {album}, {ext}
+    @Published var nameTemplate: String = "{index}. {title}.{ext}"
+    /// Overwrite policy.
+    @Published var overwritePolicy: AudioSplitter.OverwritePolicy = .rename
 
     // MARK: - Actions
     func load(audioURL: URL) {
@@ -230,8 +236,16 @@ else:
         Task {
             do {
                 let engine = TrackSplitterEngine(logHandler: handler)
-                let result = try await engine.process(inputURL: loaded.audioURL,
-                                                      outputFormat: selectedOutputFormat.audioFormat)
+                let outputConfig = TrackSplitterEngine.OutputConfig(
+                    outputDirectory: customOutputDirectory,
+                    nameTemplate: nameTemplate,
+                    overwritePolicy: overwritePolicy
+                )
+                let result = try await engine.process(
+                    inputURL: loaded.audioURL,
+                    outputFormat: selectedOutputFormat.audioFormat,
+                    outputConfig: outputConfig
+                )
                 let (coverData, _) = Completion.readCover(from: result.trackFiles)
                 let completion = Completion(
                     outputDirectory: result.outputDirectory,
@@ -262,6 +276,10 @@ else:
         progress = 0
         isShowingErrorAlert = false
         errorMessage = ""
+        selectedOutputFormat = .keepOriginal
+        customOutputDirectory = nil
+        nameTemplate = "{index}. {title}.{ext}"
+        overwritePolicy = .rename
     }
 
     // MARK: - Private

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -21,7 +21,10 @@ struct ContentView: View {
                 LoadedView(
                     loaded: loaded,
                     onStart: { viewModel.startProcessing() },
-                    selectedOutputFormat: $viewModel.selectedOutputFormat
+                    selectedOutputFormat: $viewModel.selectedOutputFormat,
+                    customOutputDirectory: $viewModel.customOutputDirectory,
+                    nameTemplate: $viewModel.nameTemplate,
+                    overwritePolicy: $viewModel.overwritePolicy
                 )
 
             case .processing:
@@ -40,7 +43,6 @@ struct ContentView: View {
                         )
                     },
                     onProcessAnother: {
-                        viewModel.selectedOutputFormat = .keepOriginal
                         viewModel.processAnother()
                     }
                 )
@@ -285,6 +287,11 @@ struct LoadedView: View {
     let loaded: SplitterViewModel.LoadedFiles
     let onStart: () -> Void
     @Binding var selectedOutputFormat: AudioSplitterOutputFormat
+    @Binding var customOutputDirectory: URL?
+    @Binding var nameTemplate: String
+    @Binding var overwritePolicy: AudioSplitter.OverwritePolicy
+
+    @State private var isShowingDirectoryPicker = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -324,7 +331,8 @@ struct LoadedView: View {
 
             Divider()
 
-            HStack {
+            // Options row
+            HStack(spacing: 16) {
                 Text("CUE: \(loaded.cueURL.lastPathComponent)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -332,9 +340,72 @@ struct LoadedView: View {
 
                 Spacer()
 
+                // Output directory
+                HStack(spacing: 6) {
+                    Text("输出目录：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let dir = customOutputDirectory {
+                        Text(dir.lastPathComponent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    } else {
+                        Text("（默认）")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button("选择...") {
+                        isShowingDirectoryPicker = true
+                    }
+                    .font(.caption)
+                    .buttonStyle(.link)
+
+                    if customOutputDirectory != nil {
+                        Button("清除") {
+                            customOutputDirectory = nil
+                        }
+                        .font(.caption)
+                        .buttonStyle(.link)
+                    }
+                }
+
+                Divider().frame(height: 16)
+
+                // Filename template
+                HStack(spacing: 6) {
+                    Text("文件名：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("{index}. {title}", text: $nameTemplate)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(width: 180)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Divider().frame(height: 16)
+
+                // Overwrite policy
+                HStack(spacing: 6) {
+                    Text("冲突：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Picker("", selection: $overwritePolicy) {
+                        Text("重命名").tag(AudioSplitter.OverwritePolicy.rename)
+                        Text("覆盖").tag(AudioSplitter.OverwritePolicy.overwrite)
+                        Text("跳过").tag(AudioSplitter.OverwritePolicy.skip)
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 90)
+                }
+
+                Divider().frame(height: 16)
+
                 // Output format selector
                 HStack(spacing: 8) {
-                    Text("输出格式：")
+                    Text("格式：")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -361,10 +432,21 @@ struct LoadedView: View {
                 }
                 .buttonStyle(.plain)
             }
-            .padding(20)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
             .background(Color(nsColor: .controlBackgroundColor))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .fileImporter(
+            isPresented: $isShowingDirectoryPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            if case .success(let urls) = result, let url = urls.first {
+                customOutputDirectory = url
+            }
+            isShowingDirectoryPicker = false
+        }
     }
 }
 

--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -130,6 +130,7 @@ public actor AudioSplitter {
         outputFormat: AudioFormat? = nil,
         nameTemplate: String = "{index}. {title}.{ext}",
         albumTitle: String = "",
+        artist: String = "",
         overwritePolicy: OverwritePolicy = .rename,
         progressHandler: @escaping @Sendable (Progress) -> Void
     ) async throws -> [URL] {
@@ -177,6 +178,7 @@ public actor AudioSplitter {
                 nameTemplate,
                 track: track,
                 albumTitle: albumTitle,
+                artist: artist,
                 ext: outExt
             )
             let outURL = resolveOutputURL(
@@ -198,7 +200,8 @@ public actor AudioSplitter {
 
             // runFFmpeg returns the actual URL written (may differ if passthrough fell back to WAV)
             let actualURL = try await runFFmpeg(input: inputURL, start: track.startSeconds,
-                                duration: duration, output: outURL, acodecArgs: acodecArg)
+                                duration: duration, output: outURL, acodecArgs: acodecArg,
+                                overwritePolicy: overwritePolicy)
             outputs.append(actualURL)
         }
 
@@ -211,13 +214,14 @@ public actor AudioSplitter {
         _ template: String,
         track: CueTrack,
         albumTitle: String,
+        artist: String,
         ext: String
     ) -> String {
         let title = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
         return template
             .replacingOccurrences(of: "{index}", with: String(track.index))
             .replacingOccurrences(of: "{title}", with: title)
-            .replacingOccurrences(of: "{artist}", with: "")
+            .replacingOccurrences(of: "{artist}", with: sanitizeFilename(artist))
             .replacingOccurrences(of: "{album}", with: sanitizeFilename(albumTitle))
             .replacingOccurrences(of: "{ext}", with: ext)
     }
@@ -241,14 +245,19 @@ public actor AudioSplitter {
     /// Runs ffmpeg and returns the actual URL that was written.
     /// If passthrough fails, falls back to PCM WAV — extension stays .wav to match actual codec.
     private func runFFmpeg(input: URL, start: Double, duration: Double,
-                           output: URL, acodecArgs: [String]) async throws -> URL {
+                           output: URL, acodecArgs: [String],
+                           overwritePolicy: OverwritePolicy) async throws -> URL {
         let isPassthrough = acodecArgs.first == "-acodec" && acodecArgs.last == "copy"
+        // .rename: file guaranteed absent by resolveOutputURL → safe to use -n
+        // .overwrite: user wants replacement → -y
+        // .skip: handled before calling runFFmpeg, never reaches here
+        let overwriteFlag = (overwritePolicy == .overwrite) ? "-y" : "-n"
 
         if isPassthrough {
             // Try stream copy first (no re-encode)
             do {
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                        output: output, extraArgs: acodecArgs)
+                                        output: output, extraArgs: acodecArgs, overwriteFlag: overwriteFlag)
                 return output
             } catch {
                 // Stream copy failed — fall back to PCM WAV.
@@ -256,25 +265,27 @@ public actor AudioSplitter {
                 try? FileManager.default.removeItem(at: output)
                 let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                        output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"])
+                                        output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"],
+                                        overwriteFlag: overwriteFlag)
                 return fallbackURL
             }
         } else {
             // Explicit codec requested (FLAC/WAV/MP3 etc.) — no stream copy fallback
             try await runFFmpegOnce(input: input, start: start, duration: duration,
-                                    output: output, extraArgs: acodecArgs)
+                                    output: output, extraArgs: acodecArgs, overwriteFlag: overwriteFlag)
             return output
         }
     }
 
     /// Run ffmpeg once with given arguments; throws on failure.
     private func runFFmpegOnce(input: URL, start: Double, duration: Double,
-                               output: URL, extraArgs: [String]) async throws {
+                               output: URL, extraArgs: [String],
+                               overwriteFlag: String = "-y") async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: ffmpegPath)
             process.arguments = [
-                "-y", "-i", input.path,
+                overwriteFlag, "-i", input.path,
                 "-ss", String(format: "%.3f", start),
                 "-t",  String(format: "%.3f", duration)
             ] + extraArgs + [output.path]

--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -116,11 +116,21 @@ public actor AudioSplitter {
     ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
     ///     Pass `.flac` to re-encode any input to FLAC (lossless, smaller file).
     ///     Pass `.wav` to re-encode to WAV (lossless PCM, larger file).
+    /// Policy for when an output file already exists.
+    public enum OverwritePolicy: String, Sendable {
+        case rename  // 重命名：已存在则加数字后缀
+        case overwrite  // 直接覆盖
+        case skip  // 跳过（保留原文件）
+    }
+
     public func split(
         file inputURL: URL,
         tracks: [CueTrack],
         to outputDir: URL,
         outputFormat: AudioFormat? = nil,
+        nameTemplate: String = "{index}. {title}.{ext}",
+        albumTitle: String = "",
+        overwritePolicy: OverwritePolicy = .rename,
         progressHandler: @escaping @Sendable (Progress) -> Void
     ) async throws -> [URL] {
         let inputExt = inputURL.pathExtension.lowercased()
@@ -163,8 +173,24 @@ public actor AudioSplitter {
 
         for track in filled {
             let duration = track.endSeconds! - track.startSeconds
-            let safe = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
-            let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).\(outExt)")
+            let rawFileName = applyNameTemplate(
+                nameTemplate,
+                track: track,
+                albumTitle: albumTitle,
+                ext: outExt
+            )
+            let outURL = resolveOutputURL(
+                outputDir: outputDir,
+                baseName: rawFileName,
+                policy: overwritePolicy
+            )
+
+            // Handle skip policy
+            if overwritePolicy == .skip && FileManager.default.fileExists(atPath: outURL.path) {
+                print("⏭️  Skipping existing: \(outURL.lastPathComponent)")
+                outputs.append(outURL)
+                continue
+            }
 
             let progress = Progress(track: track.index, total: filled.count,
                                     trackTitle: track.title, secondsProcessed: track.startSeconds)
@@ -177,6 +203,39 @@ public actor AudioSplitter {
         }
 
         return outputs
+    }
+
+    /// Expand a filename template by replacing placeholders with track metadata.
+    /// Placeholders: {index}, {title}, {artist}, {album}, {ext}
+    private func applyNameTemplate(
+        _ template: String,
+        track: CueTrack,
+        albumTitle: String,
+        ext: String
+    ) -> String {
+        let title = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
+        return template
+            .replacingOccurrences(of: "{index}", with: String(track.index))
+            .replacingOccurrences(of: "{title}", with: title)
+            .replacingOccurrences(of: "{artist}", with: "")
+            .replacingOccurrences(of: "{album}", with: sanitizeFilename(albumTitle))
+            .replacingOccurrences(of: "{ext}", with: ext)
+    }
+
+    /// Resolve output URL, applying the overwrite policy.
+    /// - For `.rename`: appends -1, -2, … if the file exists.
+    /// - For `.overwrite` / `.skip`: returns the base URL as-is.
+    private func resolveOutputURL(outputDir: URL, baseName: String, policy: OverwritePolicy) -> URL {
+        var candidate = outputDir.appendingPathComponent(baseName)
+        if policy == .rename {
+            var counter = 1
+            let nameWithoutExt = baseName.replacingOccurrences(of: ".\(candidate.pathExtension)", with: "")
+            while FileManager.default.fileExists(atPath: candidate.path) {
+                candidate = outputDir.appendingPathComponent("\(nameWithoutExt)-\(counter).\(candidate.pathExtension)")
+                counter += 1
+            }
+        }
+        return candidate
     }
 
     /// Runs ffmpeg and returns the actual URL that was written.

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -24,6 +24,27 @@ public actor TrackSplitterEngine {
         }
     }
 
+    /// 配置输出目录和文件名模板。
+    public struct OutputConfig: Sendable {
+        /// 输出目录。nil = 默认（与输入文件同目录，以 album title 为子目录）。
+        public var outputDirectory: URL?
+        /// 文件名模板，支持占位符：{index}、{title}、{artist}、{album}、{ext}
+        /// 默认值："{index}. {title}.{ext}"
+        public var nameTemplate: String
+        /// 覆写策略。
+        public var overwritePolicy: AudioSplitter.OverwritePolicy
+
+        public init(
+            outputDirectory: URL? = nil,
+            nameTemplate: String = "{index}. {title}.{ext}",
+            overwritePolicy: AudioSplitter.OverwritePolicy = .rename
+        ) {
+            self.outputDirectory = outputDirectory
+            self.nameTemplate = nameTemplate
+            self.overwritePolicy = overwritePolicy
+        }
+    }
+
     public struct Result: Sendable {
         public let outputDirectory: URL
         public let trackFiles: [URL]
@@ -60,7 +81,12 @@ public actor TrackSplitterEngine {
     ///   - outputFormat: Desired output format. nil = same as input (passthrough, no re-encode).
     ///     `.flac` = re-encode to FLAC (lossless, smaller file).
     ///     `.wav` = re-encode to WAV (lossless PCM, larger file).
-    public func process(inputURL: URL, outputFormat: AudioSplitter.AudioFormat? = nil) async throws -> Result {
+    ///   - outputConfig: Output directory, filename template, and overwrite policy.
+    public func process(
+        inputURL: URL,
+        outputFormat: AudioSplitter.AudioFormat? = nil,
+        outputConfig: OutputConfig? = nil
+    ) async throws -> Result {
         log("📂 Input: \(inputURL.lastPathComponent)")
 
         // 1. Find CUE — scan all .cue files in the same directory and validate via FILE field
@@ -88,15 +114,24 @@ public actor TrackSplitterEngine {
 
         guard !tracks.isEmpty else { throw EngineError.emptyTracks }
 
-        // 3. Create output directory
+        // 3. Resolve output directory
+        let cfg = outputConfig ?? OutputConfig()
         let albumDirName = albumTitle ?? inputURL.deletingPathExtension().lastPathComponent
-        let outDir = inputURL.deletingLastPathComponent().appendingPathComponent(albumDirName)
+        let outDir: URL
+        if let customDir = cfg.outputDirectory {
+            outDir = customDir
+        } else {
+            outDir = inputURL.deletingLastPathComponent().appendingPathComponent(albumDirName)
+        }
         do {
             try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
         } catch {
             throw EngineError.outputDirCreationFailed
         }
         log("📁 Output dir: \(outDir.path)")
+        if cfg.outputDirectory != nil {
+            log("📁 (custom directory)")
+        }
 
         // 4. Fetch cover art (non-fatal)
         var coverData: Data? = nil
@@ -116,7 +151,10 @@ public actor TrackSplitterEngine {
                 file: inputURL,
                 tracks: tracks,
                 to: outDir,
-                outputFormat: outputFormat
+                outputFormat: outputFormat,
+                nameTemplate: cfg.nameTemplate,
+                albumTitle: albumTitle ?? albumDirName,
+                overwritePolicy: cfg.overwritePolicy
             ) { [weak self] progress in
                 Task { await self?.log("  Splitting track \(progress.track)/\(progress.total): \(progress.trackTitle)...") }
             }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -154,6 +154,7 @@ public actor TrackSplitterEngine {
                 outputFormat: outputFormat,
                 nameTemplate: cfg.nameTemplate,
                 albumTitle: albumTitle ?? albumDirName,
+                artist: performer ?? "",
                 overwritePolicy: cfg.overwritePolicy
             ) { [weak self] progress in
                 Task { await self?.log("  Splitting track \(progress.track)/\(progress.total): \(progress.trackTitle)...") }


### PR DESCRIPTION
## 背景

Issue #3：输出目录和文件名格式无配置选项。

TrackSplitter 原来所有路径都是代码写死的：
- 输出目录固定在输入文件同目录下，以 album title 为子目录
- 文件名格式固定为 `{index}. {title}.flac`

## 修改内容

### Engine (TrackSplitterEngine)
新增 `OutputConfig` 结构体：
- `outputDirectory: URL?` — 自定义输出目录，nil = 默认行为
- `nameTemplate: String` — 文件名模板，默认 `{index}. {title}.{ext}`
- `overwritePolicy: AudioSplitter.OverwritePolicy` — 覆写策略（rename/overwrite/skip）

### AudioSplitter
- `split()` 新增 `nameTemplate`、`albumTitle`、`overwritePolicy` 参数
- `applyNameTemplate()` — 展开占位符：{index}、{title}、{artist}、{album}、{ext}
- `resolveOutputURL()` — 应用覆写策略（.rename 在文件名后加 -1 -2 …）

### CLI
新增三个选项：
- `--output-dir <path>` — 指定输出目录
- `--name-template <tmpl>` — 文件名模板
- `--overwrite <policy>` — 覆写策略（rename|overwrite|skip）

### GUI
LoadedView 新增配置行：
- **输出目录**：选择按钮 + 清除按钮（nil = 默认）
- **文件名**：模板文本框（等宽字体）
- **冲突**：重命名 / 覆盖 / 跳过 picker
- 位于曲目列表和"开始拆分"按钮之间

## 验证

- `swift build` ✅
- `swift test` ✅
