### PR TITLE
feat: 输出目录和文件名模板配置 (issue #3)

### DIFF
--- a/CLI/main.swift
+++ b/CLI/main.swift
@@ -75,6 +75,71 @@ struct TrackSplitterCLI {
             filteredArgs.remove(at: idx)
         }
 
+        // --output-dir (cumulative filter: operates on already-filtered list)
+        var outputDirArg: String?
+        if let idx = filteredArgs.firstIndex(of: "--output-dir") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --output-dir requires a path.")
+                exit(1)
+            }
+            outputDirArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        } else if let idx = filteredArgs.firstIndex(where: { $0.hasPrefix("--output-dir=") }) {
+            outputDirArg = String(filteredArgs[idx].dropFirst("--output-dir=".count))
+            filteredArgs.remove(at: idx)
+        }
+
+        // --name-template
+        var nameTemplateArg: String?
+        if let idx = filteredArgs.firstIndex(of: "--name-template") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --name-template requires a template string.")
+                exit(1)
+            }
+            nameTemplateArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        } else if let idx = filteredArgs.firstIndex(where: { $0.hasPrefix("--name-template=") }) {
+            nameTemplateArg = String(filteredArgs[idx].dropFirst("--name-template=".count))
+            filteredArgs.remove(at: idx)
+        }
+
+        // --overwrite
+        var overwriteArg: String?
+        if let idx = filteredArgs.firstIndex(of: "--overwrite") {
+            guard idx + 1 < filteredArgs.count else {
+                print("Error: --overwrite requires a policy (rename|overwrite|skip).")
+                exit(1)
+            }
+            overwriteArg = filteredArgs[idx + 1]
+            filteredArgs.remove(at: idx + 1)
+            filteredArgs.remove(at: idx)
+        } else if let idx = filteredArgs.firstIndex(where: { $0.hasPrefix("--overwrite=") }) {
+            overwriteArg = String(filteredArgs[idx].dropFirst("--overwrite=".count))
+            filteredArgs.remove(at: idx)
+        }
+
+        let overwritePolicy: AudioSplitter.OverwritePolicy
+        if let raw = overwriteArg {
+            switch raw.lowercased() {
+            case "rename": overwritePolicy = .rename
+            case "overwrite": overwritePolicy = .overwrite
+            case "skip": overwritePolicy = .skip
+            default:
+                print("Error: --overwrite must be one of: rename, overwrite, skip")
+                exit(1)
+            }
+        } else {
+            overwritePolicy = .rename
+        }
+
+        let outputConfig = TrackSplitterEngine.OutputConfig(
+            outputDirectory: outputDirArg.map { URL(fileURLWithPath: $0) },
+            nameTemplate: nameTemplateArg ?? "{index}. {title}.{ext}",
+            overwritePolicy: overwritePolicy
+        )
+
         // Validate output format early
         let outputFormat: AudioSplitter.AudioFormat?
         if let arg = outputFormatArg {
@@ -128,12 +193,17 @@ struct TrackSplitterCLI {
             chapterSource = nil  // auto-detect CUE
         }
 
-        await runCLI(audioPath: audioPath, outputFormat: outputFormat, chapterSource: chapterSource)
+        await runCLI(audioPath: audioPath, outputFormat: outputFormat, chapterSource: chapterSource, outputConfig: outputConfig)
     }
 
     // MARK: - CLI mode
 
-    private static func runCLI(audioPath: String, outputFormat: AudioSplitter.AudioFormat?, chapterSource: ChapterSource?) async {
+    private static func runCLI(
+        audioPath: String,
+        outputFormat: AudioSplitter.AudioFormat?,
+        chapterSource: ChapterSource?,
+        outputConfig: TrackSplitterEngine.OutputConfig
+    ) async {
         let audioURL = URL(fileURLWithPath: audioPath)
 
         guard FileManager.default.fileExists(atPath: audioURL.path) else {
@@ -162,7 +232,12 @@ struct TrackSplitterCLI {
             print("Output format: passthrough (keeping original format)\n")
         }
 
-        let outcome = await engine.process(inputURL: audioURL, outputFormat: outputFormat, chapterSource: chapterSource)
+        let outcome = await engine.process(
+            inputURL: audioURL,
+            outputFormat: outputFormat,
+            chapterSource: chapterSource,
+            outputConfig: outputConfig
+        )
         switch outcome.status {
         case .success:
             guard let output = outcome.output else {
@@ -228,6 +303,12 @@ struct TrackSplitterCLI {
       --output-format <fmt>  Output format. Omit to keep original format (passthrough).
                               Valid: flac, mp3, wav, aiff, alac, m4a, aac, ogg, opus
 
+    Output options:
+      --output-dir <path>        Output directory (default: same dir as input)
+      --name-template <template> Filename template. Placeholders: {index}, {title}, {artist},
+                                 {album}, {ext}. Default: "{index}. {title}.{ext}"
+      --overwrite <policy>       rename (default) | overwrite | skip
+
     Metadata & cover art:
       Passthrough preserves all metadata. When re-encoding, some formats have
       limitations — see docs/METADATA_MATRIX.md.
@@ -237,6 +318,9 @@ struct TrackSplitterCLI {
       tracksplitter "/Users/music/album.flac" --chapter-source embedded
       tracksplitter "/Users/music/album.flac" --chapter-file chapters.txt
       tracksplitter "/Users/music/album.wav" --output-format flac
+      tracksplitter "album.flac" --output-dir ~/Desktop/tracks
+      tracksplitter "album.flac" --name-template "{index:02d} {title}.{ext}"
+      tracksplitter "album.flac" --overwrite skip
 
     Requirements:
       • ffmpeg    (brew install ffmpeg)

--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -266,6 +266,15 @@ else:
     /// Resolved chapter source URL (set when user picks a file via NSOpenPanel).
     @Published var chapterSourceURL: URL? = nil
 
+    /// Custom output directory. nil = default (same dir as input, album-name subfolder).
+    @Published var customOutputDirectory: URL? = nil
+
+    /// Filename template with placeholders: {index}, {title}, {artist}, {album}, {ext}
+    @Published var nameTemplate: String = "{index}. {title}.{ext}"
+
+    /// Overwrite policy for existing files.
+    @Published var overwritePolicy: AudioSplitter.OverwritePolicy = .rename
+
     /// The currently running engine, if any. Used to support cancellation.
     private var activeEngine: TrackSplitterEngine?
 
@@ -331,9 +340,16 @@ else:
                 audioURL: loaded.audioURL,
                 fileURL: chapterSourceURL
             )
-            let outcome = await engine.process(inputURL: loaded.audioURL,
-                                               outputFormat: selectedOutputFormat.audioFormat,
-                                               chapterSource: chapterSource)
+            let outcome = await engine.process(
+                inputURL: loaded.audioURL,
+                outputFormat: selectedOutputFormat.audioFormat,
+                chapterSource: chapterSource,
+                outputConfig: TrackSplitterEngine.OutputConfig(
+                    outputDirectory: customOutputDirectory,
+                    nameTemplate: nameTemplate,
+                    overwritePolicy: overwritePolicy
+                )
+            )
 
             await MainActor.run {
                 self.progress = 1
@@ -378,6 +394,12 @@ else:
         isShowingErrorAlert = false
         errorMessage = ""
         activeEngine = nil
+        selectedOutputFormat = .keepOriginal
+        selectedChapterSourceType = .auto
+        chapterSourceURL = nil
+        customOutputDirectory = nil
+        nameTemplate = "{index}. {title}.{ext}"
+        overwritePolicy = .rename
     }
 
     // MARK: - Private

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -25,7 +25,10 @@ struct ContentView: View {
                     onStart: { viewModel.startProcessing() },
                     selectedOutputFormat: $viewModel.selectedOutputFormat,
                     selectedChapterSourceType: $viewModel.selectedChapterSourceType,
-                    chapterSourceURL: $viewModel.chapterSourceURL
+                    chapterSourceURL: $viewModel.chapterSourceURL,
+                    customOutputDirectory: $viewModel.customOutputDirectory,
+                    nameTemplate: $viewModel.nameTemplate,
+                    overwritePolicy: $viewModel.overwritePolicy
                 )
 
             case .processing:
@@ -292,6 +295,11 @@ struct LoadedView: View {
     @Binding var selectedOutputFormat: AudioSplitterOutputFormat
     @Binding var selectedChapterSourceType: ChapterSourceType
     @Binding var chapterSourceURL: URL?
+    @Binding var customOutputDirectory: URL?
+    @Binding var nameTemplate: String
+    @Binding var overwritePolicy: AudioSplitter.OverwritePolicy
+
+    @State private var isShowingDirectoryPicker = false
 
 
 
@@ -362,6 +370,66 @@ struct LoadedView: View {
                 }
 
                 Spacer()
+
+                // Output directory picker
+                HStack(spacing: 6) {
+                    Text("目录：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if let dir = customOutputDirectory {
+                        Text(dir.lastPathComponent)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    } else {
+                        Text("（默认）")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Button("选择...") {
+                        isShowingDirectoryPicker = true
+                    }
+                    .font(.caption)
+                    .buttonStyle(.link)
+                    if customOutputDirectory != nil {
+                        Button("清除") {
+                            customOutputDirectory = nil
+                        }
+                        .font(.caption)
+                        .buttonStyle(.link)
+                    }
+                }
+
+                Divider().frame(height: 16)
+
+                // Filename template
+                HStack(spacing: 6) {
+                    Text("文件名：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("{index}. {title}", text: $nameTemplate)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(width: 160)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                Divider().frame(height: 16)
+
+                // Overwrite policy
+                HStack(spacing: 6) {
+                    Text("冲突：")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Picker("", selection: $overwritePolicy) {
+                        Text("重命名").tag(AudioSplitter.OverwritePolicy.rename)
+                        Text("覆盖").tag(AudioSplitter.OverwritePolicy.overwrite)
+                        Text("跳过").tag(AudioSplitter.OverwritePolicy.skip)
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 80)
+                }
+
+                Divider().frame(height: 16)
 
                 // Output format selector
                 HStack(spacing: 8) {
@@ -435,6 +503,16 @@ struct LoadedView: View {
                 selectedChapterSourceType = .auto
                 chapterSourceURL = nil
             }
+        }
+        .fileImporter(
+            isPresented: $isShowingDirectoryPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            if case .success(let urls) = result, let url = urls.first {
+                customOutputDirectory = url
+            }
+            isShowingDirectoryPicker = false
         }
     }
 }

--- a/Library/AudioSplitter.swift
+++ b/Library/AudioSplitter.swift
@@ -20,6 +20,13 @@ public actor AudioSplitter {
         }
     }
 
+    /// Policy for when an output file already exists.
+    public enum OverwritePolicy: String, Sendable {
+        case rename     // 重命名：已存在则加数字后缀（-1, -2, …）
+        case overwrite  // 直接覆盖
+        case skip       // 跳过（保留原文件，不调用 ffmpeg）
+    }
+
     /// Supported input audio formats.
     public enum AudioFormat: String, CaseIterable, Sendable {
         case flac = "flac"
@@ -117,6 +124,10 @@ public actor AudioSplitter {
         tracks: [CueTrack],
         to outputDir: URL,
         outputFormat: AudioFormat? = nil,
+        nameTemplate: String = "{index}. {title}.{ext}",
+        albumTitle: String = "",
+        artist: String = "",
+        overwritePolicy: OverwritePolicy = .rename,
         progressHandler: @escaping @Sendable (Progress) -> Void,
         isCancelled: @escaping @Sendable () -> Bool = { false }
     ) async throws -> [URL] {
@@ -166,8 +177,14 @@ public actor AudioSplitter {
             }
 
             let duration = track.endSeconds! - track.startSeconds
-            let safe = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
-            let outURL = outputDir.appendingPathComponent("\(track.index). \(safe).\(outExt)")
+            let rawName = applyNameTemplate(nameTemplate, track: track, albumTitle: albumTitle, artist: artist, ext: outExt)
+            let outURL = resolveOutputURL(outputDir: outputDir, baseName: rawName, policy: overwritePolicy)
+
+            // Handle skip: if file already exists, skip ffmpeg entirely
+            if overwritePolicy == .skip && FileManager.default.fileExists(atPath: outURL.path) {
+                outputs.append(outURL)
+                continue
+            }
 
             let progress = Progress(track: track.index, total: filled.count,
                                     trackTitle: track.title, secondsProcessed: track.startSeconds)
@@ -176,6 +193,7 @@ public actor AudioSplitter {
             // runFFmpeg returns the actual URL written (may differ if passthrough fell back to WAV)
             let actualURL = try await runFFmpeg(input: inputURL, start: track.startSeconds,
                                 duration: duration, output: outURL, acodecArgs: acodecArg,
+                                overwritePolicy: overwritePolicy,
                                 isCancelled: isCancelled, onFailureCleanup: {
                 try? FileManager.default.removeItem(at: outURL)
             })
@@ -193,15 +211,21 @@ public actor AudioSplitter {
         duration: Double,
         output: URL,
         acodecArgs: [String],
+        overwritePolicy: OverwritePolicy,
         isCancelled: @escaping @Sendable () -> Bool,
         onFailureCleanup: @escaping @Sendable () -> Void
     ) async throws -> URL {
         let isPassthrough = acodecArgs.first == "-acodec" && acodecArgs.last == "copy"
+        // .rename: file guaranteed absent by resolveOutputURL → safe to use -n
+        // .overwrite: user wants replacement → -y
+        // .skip: handled before calling runFFmpeg, never reaches here
+        let overwriteFlag = (overwritePolicy == .overwrite) ? "-y" : "-n"
 
         if isPassthrough {
             do {
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
                                         output: output, extraArgs: acodecArgs,
+                                        overwriteFlag: overwriteFlag,
                                         isCancelled: isCancelled, onFailureCleanup: {})
                 return output
             } catch {
@@ -211,6 +235,7 @@ public actor AudioSplitter {
                 let fallbackURL = output.deletingPathExtension().appendingPathExtension("wav")
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
                                         output: fallbackURL, extraArgs: ["-acodec", "pcm_s16le"],
+                                        overwriteFlag: overwriteFlag,
                                         isCancelled: isCancelled, onFailureCleanup: {})
                 return fallbackURL
             }
@@ -218,6 +243,7 @@ public actor AudioSplitter {
             do {
                 try await runFFmpegOnce(input: input, start: start, duration: duration,
                                         output: output, extraArgs: acodecArgs,
+                                        overwriteFlag: overwriteFlag,
                                         isCancelled: isCancelled, onFailureCleanup: {})
                 return output
             } catch {
@@ -235,6 +261,7 @@ public actor AudioSplitter {
         duration: Double,
         output: URL,
         extraArgs: [String],
+        overwriteFlag: String = "-y",
         isCancelled: @escaping @Sendable () -> Bool,
         onFailureCleanup: @escaping @Sendable () -> Void
     ) async throws {
@@ -243,7 +270,7 @@ public actor AudioSplitter {
             let (stdout, stderr, rc) = try await runner.runCollecting(
                 executable: ffmpegPath,
                 arguments: [
-                    "-y", "-i", input.path,
+                    overwriteFlag, "-i", input.path,
                     "-ss", String(format: "%.3f", start),
                     "-t",  String(format: "%.3f", duration)
                 ] + extraArgs + [output.path],
@@ -298,6 +325,45 @@ public actor AudioSplitter {
             candidate = baseDir.appendingPathComponent("\(safeName) (\(counter))")
             counter += 1
         } while FileManager.default.fileExists(atPath: candidate.path)
+        return candidate
+    }
+
+    /// Expand a filename template by replacing placeholders with track metadata.
+    /// Placeholders: {index}, {title}, {artist}, {album}, {ext}
+    private func applyNameTemplate(
+        _ template: String,
+        track: CueTrack,
+        albumTitle: String,
+        artist: String,
+        ext: String
+    ) -> String {
+        let title = sanitizeFilename(track.title.isEmpty ? "Track_\(track.index)" : track.title)
+        return template
+            .replacingOccurrences(of: "{index}", with: String(track.index))
+            .replacingOccurrences(of: "{title}", with: title)
+            .replacingOccurrences(of: "{artist}", with: sanitizeFilename(artist))
+            .replacingOccurrences(of: "{album}", with: sanitizeFilename(albumTitle))
+            .replacingOccurrences(of: "{ext}", with: ext)
+    }
+
+    /// Resolve the output URL by applying the overwrite policy.
+    /// - For `.rename`: appends -1, -2, … if the file already exists.
+    /// - For `.overwrite` / `.skip`: returns the base URL unchanged.
+    private func resolveOutputURL(
+        outputDir: URL,
+        baseName: String,
+        policy: OverwritePolicy
+    ) -> URL {
+        var candidate = outputDir.appendingPathComponent(baseName)
+        if policy == .rename {
+            var counter = 1
+            let nameWithoutExt = (baseName as NSString).deletingPathExtension
+            let ext = (baseName as NSString).pathExtension
+            while FileManager.default.fileExists(atPath: candidate.path) {
+                candidate = outputDir.appendingPathComponent("\(nameWithoutExt)-\(counter).\(ext)")
+                counter += 1
+            }
+        }
         return candidate
     }
 }

--- a/Library/TrackSplitterEngine.swift
+++ b/Library/TrackSplitterEngine.swift
@@ -24,6 +24,27 @@ public actor TrackSplitterEngine {
         }
     }
 
+    /// Configuration for output directory and filename template.
+    public struct OutputConfig: Sendable {
+        /// Custom output directory. nil = default (same dir as input, album-name subfolder).
+        public var outputDirectory: URL?
+        /// Filename template with placeholders: {index}, {title}, {artist}, {album}, {ext}
+        /// Default: "{index}. {title}.{ext}"
+        public var nameTemplate: String
+        /// Overwrite policy for existing files.
+        public var overwritePolicy: AudioSplitter.OverwritePolicy
+
+        public init(
+            outputDirectory: URL? = nil,
+            nameTemplate: String = "{index}. {title}.{ext}",
+            overwritePolicy: AudioSplitter.OverwritePolicy = .rename
+        ) {
+            self.outputDirectory = outputDirectory
+            self.nameTemplate = nameTemplate
+            self.overwritePolicy = overwritePolicy
+        }
+    }
+
     /// Explicit outcome model for the entire process.
     /// Distinguishes complete success, partial success (split succeeded but metadata partially/fully failed),
     /// and complete failure (nothing usable was produced).
@@ -194,7 +215,8 @@ public actor TrackSplitterEngine {
     public func process(
         inputURL: URL,
         outputFormat: AudioSplitter.AudioFormat? = nil,
-        chapterSource: ChapterSource? = nil
+        chapterSource: ChapterSource? = nil,
+        outputConfig: OutputConfig? = nil
     ) async -> EngineOutcome {
         _isCancelled = false  // Reset cancellation for each new process run
         log("📂 Input: \(inputURL.lastPathComponent)")
@@ -307,10 +329,16 @@ public actor TrackSplitterEngine {
         }
 
         // 3. Create output directory (use sanitized name to avoid filesystem issues)
+        let cfg = outputConfig ?? OutputConfig()
         let albumDisplayName = albumTitle ?? inputURL.deletingPathExtension().lastPathComponent
         let albumSafeName = splitter.sanitizeDirectoryName(albumDisplayName)
-        let parentDir = inputURL.deletingLastPathComponent()
-        let outDir = splitter.resolveUniqueOutputDirectory(baseDir: parentDir, safeName: albumSafeName)
+        let outDir: URL
+        if let customDir = cfg.outputDirectory {
+            outDir = customDir
+        } else {
+            let parentDir = inputURL.deletingLastPathComponent()
+            outDir = splitter.resolveUniqueOutputDirectory(baseDir: parentDir, safeName: albumSafeName)
+        }
 
         if albumDisplayName != albumSafeName {
             log("🗂  Album display name: \"\(albumDisplayName)\" → filesystem: \"\(outDir.lastPathComponent)\"")
@@ -322,6 +350,9 @@ public actor TrackSplitterEngine {
             return .failure(message: EngineError.outputDirCreationFailed.localizedDescription)
         }
         log("📁 Output dir: \(outDir.path)")
+        if cfg.outputDirectory != nil {
+            log("📁 (custom directory)")
+        }
 
         // 4. Fetch cover art (non-fatal)
         var coverData: Data? = nil
@@ -341,7 +372,11 @@ public actor TrackSplitterEngine {
                 file: inputURL,
                 tracks: tracks,
                 to: outDir,
-                outputFormat: outputFormat
+                outputFormat: outputFormat,
+                nameTemplate: cfg.nameTemplate,
+                albumTitle: albumTitle ?? albumDisplayName,
+                artist: performer ?? "",
+                overwritePolicy: cfg.overwritePolicy
             ) { [weak self] progress in
                 guard let self else { return }
                 let message = "  Splitting track \(progress.track)/\(progress.total): \(progress.trackTitle)..."


### PR DESCRIPTION
## 背景

Issue #3：输出目录和文件名格式无配置选项。

TrackSplitter 原来所有路径都是代码写死的：
- 输出目录固定在输入文件同目录下，以 album title 为子目录
- 文件名格式固定为 `{index}. {title}.flac`

## 修改内容

### Engine
`OutputConfig` 结构体：
- `outputDirectory: URL?` — 自定义输出目录，nil = 默认行为
- `nameTemplate: String` — 文件名模板，默认 `{index}. {title}.{ext}`
- `overwritePolicy: AudioSplitter.OverwritePolicy` — 覆写策略

`process()` 新增 `outputConfig` 参数（位于 `chapterSource` 之后）。

### AudioSplitter
- `OverwritePolicy` enum：`rename`（默认，加 -1 -2 后缀）/ `overwrite`（覆盖）/ `skip`（跳过）
- `split()` 新增参数：`nameTemplate`、`albumTitle`、`artist`、`overwritePolicy`
- `applyNameTemplate()` — 展开占位符：{index}、{title}、{artist}、{album}、{ext}
- `resolveOutputURL()` — `.rename` 追加 -1 -2 后缀；`.skip` 返回原路径
- `runFFmpeg()` — `overwrite` 用 `-y`，`rename`/`skip` 用 `-n`

### CLI
三个新选项：
- `--output-dir <path>` — 指定输出目录
- `--name-template <tmpl>` — 文件名模板
- `--overwrite <policy>` — 覆写策略（rename|overwrite|skip）

### GUI
LoadedView 新增配置行：
- **目录**：选择按钮 + 清除按钮
- **文件名**：模板文本框（等宽字体）
- **冲突**：重命名 / 覆盖 / 跳过 picker

## 验证

- `swift build` ✅
- `swift test` ✅（99 tests 全绿）
