### PR TITLE
fix(TextChapterParser): 明确并修正 MM:SS / HH:MM:SS 时间戳语义 (issue #55)

### DIFF
--- a/Library/ChapterSource.swift
+++ b/Library/ChapterSource.swift
@@ -121,10 +121,12 @@ public struct TextChapterParser: Sendable {
 
     /// Parse a timestamp from a line and return the seconds value + remainder of line.
     private func parseTimestampLine(_ line: String) -> (seconds: Double, rest: String)? {
-        // Supported formats:
-        //   00:00:00 Title
-        //   [00:00:00] Title
-        //   00:00:00.500 Title
+        // Supported formats (semantics are explicit — do not mix):
+        //   MM:SS           → minutes:seconds  (e.g. 03:45 = 3 min 45 sec)
+        //   HH:MM:SS        → hours:minutes:seconds  (e.g. 1:02:03 = 1h 2m 3s)
+        //   HH:MM:SS.mmm    → hours:minutes:seconds.subseconds  (e.g. 00:03:45.500 = 3m 45.5s)
+        //   [MM:SS] Title
+        //   [HH:MM:SS] Title
         var work = line.trimmingCharacters(in: .whitespaces)
 
         var rest = ""
@@ -132,10 +134,8 @@ public struct TextChapterParser: Sendable {
         // Strip matched [ ... ] pair and preserve anything after the closing ]
         if work.hasPrefix("[") {
             if let endBracket = work.firstIndex(of: "]") {
-                // textAfter = everything after the closing ]
                 let afterBracket = work.index(after: endBracket)
                 rest = String(work[afterBracket...]).trimmingCharacters(in: .whitespaces)
-                // work = content inside brackets
                 work = String(work[work.index(after: work.startIndex)..<endBracket])
             }
         }
@@ -145,18 +145,30 @@ public struct TextChapterParser: Sendable {
         guard let first = parts.first else { return nil }
         let tsString = String(first)
 
-        // Parse H:M:S[.f]
         let tsComponents = tsString.split(separator: ":")
         guard tsComponents.count == 2 || tsComponents.count == 3 else { return nil }
 
-        guard let hours = Double(tsComponents[0]),
-              let minutes = Double(tsComponents[1]) else { return nil }
+        var totalSeconds: Double = 0
 
-        var totalSeconds: Double = minutes * 60 + hours * 3600
-
-        if tsComponents.count == 3 {
-            guard let sec = Double(tsComponents[2]) else { return nil }
-            totalSeconds += sec
+        if tsComponents.count == 2 {
+            // MM:SS format — first component is minutes, second is seconds
+            guard let mm = Double(tsComponents[0]),
+                  let ss = Double(tsComponents[1]) else { return nil }
+            totalSeconds = mm * 60 + ss
+        } else {
+            // HH:MM:SS[.mmm] format — third component may have subseconds
+            guard let hh = Double(tsComponents[0]),
+                  let mm = Double(tsComponents[1]) else { return nil }
+            let secStr = String(tsComponents[2])
+            // Support fractional seconds: split on "." if present
+            let secComponents = secStr.split(separator: ".", maxSplits: 1)
+            guard let sec = Double(secComponents[0]) else { return nil }
+            totalSeconds = hh * 3600 + mm * 60 + sec
+            if secComponents.count == 2 {
+                // Fractional part: ".500" → 0.5 seconds
+                let frac = Double("0." + String(secComponents[1])) ?? 0
+                totalSeconds += frac
+            }
         }
 
         // If no rest was extracted from the [bracket] form, use the remainder from work.split

--- a/Tests/ChapterSourceTests.swift
+++ b/Tests/ChapterSourceTests.swift
@@ -40,6 +40,56 @@ final class ChapterSourceTests: XCTestCase {
         XCTAssertEqual(entries[2].startSeconds, 450)
     }
 
+    func testTextChapterParser_MMSS_semantics() throws {
+        // Issue #55: 03:45 must be interpreted as 3 minutes 45 seconds (=225s),
+        // NOT 3 hours 45 minutes (=13500s).
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try "03:45 Title\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].startSeconds, 225)  // 3*60 + 45 = 225
+        XCTAssertEqual(entries[0].title, "Title")
+    }
+
+    func testTextChapterParser_HHMMSSSemantics() throws {
+        // 1:02:03 = 1h 02m 03s = 3723s
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try "1:02:03 Title\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].startSeconds, 3723)  // 1*3600 + 2*60 + 3
+    }
+
+    func testTextChapterParser_bracketMMSS() throws {
+        // [03:45] = 3 minutes 45 seconds = 225s (MM:SS inside brackets)
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try "[03:45] Title\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].startSeconds, 225)
+    }
+
+    func testTextChapterParser_subseconds() throws {
+        // 00:03:45.500 = 3m 45.5s = 225.5s
+        let file = tempDir.appendingPathComponent("chapters.txt")
+        try "00:03:45.500 Title\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let parser = TextChapterParser()
+        let entries = try parser.parse(at: file)
+
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries[0].startSeconds, 225.5, accuracy: 0.001)
+    }
+
     func testTextChapterParser_dashSeparator() throws {
         let file = tempDir.appendingPathComponent("chapters.txt")
         try """


### PR DESCRIPTION
## 背景

Issue #55：`TextChapterParser.parseTimestampLine()` 对时间戳格式的语义存在歧义。

原来代码对 2 段和 3 段时间戳用同一套换算逻辑处理：
```
guard let hours = Double(tsComponents[0]),
      let minutes = Double(tsComponents[1]) else { return nil }
totalSeconds = minutes * 60 + hours * 3600
```

这导致 `03:45` 被解析为 3 小时 45 分（13500 秒），而不是用户预期的 3 分 45 秒（225 秒）。

## 修改内容

`parseTimestampLine()` 改为按组件数量区分语义：

| 格式 | 示例 | 解析 |
|------|------|------|
| MM:SS | `03:45` | minutes:seconds = 225s |
| HH:MM:SS | `1:02:03` | hours:minutes:seconds = 3723s |
| HH:MM:SS.mmm | `00:03:45.500` | 支持亚秒精度 = 225.5s |

同时修复了亚秒解析的 bug（原来 `00:03:45.500` 的 `.500` 部分不会被正确解析为 0.5 秒）。

## 验收测试（新增）

- `03:45 Title` → 225 秒 ✅
- `1:02:03 Title` → 3723 秒 ✅
- `[03:45] Title` → 225 秒 ✅
- `00:03:45.500 Title` → 225.5 秒 ✅

## 验证

- `swift build` ✅
- `swift test` ✅（103 tests 全绿）
