### PR TITLE
fix(AlbumArtFetcher): provider 返回 nil 时不再被 timeout 误判为 error (issue #52)

### DIFF
--- a/Library/AlbumArtFetcher.swift
+++ b/Library/AlbumArtFetcher.swift
@@ -174,7 +174,8 @@ public actor AlbumArtFetcher {
 
     /// Wrapper that runs a provider with timeout and returns a structured result.
     /// On success, the data is stored in cache before the result is returned.
-    private func attempt(
+    /// internal for testing; production callers should use the public `fetch()` method.
+    func attempt(
         provider: any CoverProvider,
         artist: String?,
         album: String,
@@ -185,32 +186,41 @@ public actor AlbumArtFetcher {
 
             struct TimeoutError: Error {}
 
-            let fetchedData: Data? = try await withThrowingTaskGroup(of: Data?.self) { group in
+            // Use Result<Data?, Error> so nil (no cover found at this source) is a
+            // valid success value, not a continuation of the loop. Only timeout's
+            // throw reaches the catch block as .error.
+            let result = try await withThrowingTaskGroup(of: Result<Data?, Error>.self) { (group: inout ThrowingTaskGroup<Result<Data?, Error>, Error>) in
                 // Timeout task — throws to stop the group
-                group.addTask {
+                group.addTask { @Sendable in
                     try await Task.sleep(nanoseconds: timeoutNanos)
                     throw TimeoutError()
                 }
-                // Provider task
-                group.addTask {
-                    try await provider.fetch(artist: artist, album: album, inputFile: inputFile)
+                // Provider task — nil means "no cover at this source", not an error
+                group.addTask { @Sendable in
+                    let data = try await provider.fetch(artist: artist, album: album, inputFile: inputFile)
+                    return Result<Data?, Error>.success(data)
                 }
 
-                // Return first non-nil result; propagate nil as "not found"
-                for try await result in group {
-                    if let d = result {
-                        return d
-                    }
-                }
-                return nil
+                // First completed task wins
+                guard let r = try await group.next() else { return Result<Data?, Error>.success(nil) }
+                // Cancel remaining work — we already have our answer
+                group.cancelAll()
+                return r
             }
 
-            if let data = fetchedData {
+            // Interpret result
+            switch result {
+            case .success(let data?):
+                // Found a cover
                 let key = CoverCache.CacheKey(artist: artist, album: album)
                 await cache.set(key, data: data)
                 return .success(providerName: provider.name, sizeBytes: data.count)
-            } else {
+            case .success(nil):
+                // Provider returned nil — not an error, just "not found at this source"
                 return .notFound(providerName: provider.name)
+            case .failure(let err):
+                // Timeout or provider threw — propagate as error
+                throw err
             }
         } catch {
             // Timeout or provider error

--- a/Tests/AlbumArtFetcherTests.swift
+++ b/Tests/AlbumArtFetcherTests.swift
@@ -175,6 +175,34 @@ final class AlbumArtFetcherPipelineTests: XCTestCase {
     }
 }
 
+// MARK: - AlbumArtFetcher attempt() tests (issue #52)
+
+/// Tests that provider returning nil is treated as .notFound, not .error.
+final class AlbumArtFetcherAttemptTests: XCTestCase {
+    func testProviderReturningNilGivesNotFound() async throws {
+        let fetcher = AlbumArtFetcher(cache: CoverCache(), config: .init())
+        let provider = MockNotFoundProvider(name: "NotFound")
+        let result = await fetcher.attempt(provider: provider, artist: nil, album: "Test", inputFile: nil)
+        XCTAssertEqual(result.status, .notFound)
+    }
+
+    func testProviderThrowingGivesError() async throws {
+        let fetcher = AlbumArtFetcher(cache: CoverCache(), config: .init())
+        let provider = MockErrorProvider(name: "Error")
+        let result = await fetcher.attempt(provider: provider, artist: nil, album: "Test", inputFile: nil)
+        XCTAssertEqual(result.status, .error)
+    }
+
+    func testProviderReturningDataGivesSuccess() async throws {
+        let fetcher = AlbumArtFetcher(cache: CoverCache(), config: .init())
+        let data = Data([0xFF, 0xD8, 0xFF, 0xE0])
+        let provider = MockSuccessProvider(name: "Success", data: data)
+        let result = await fetcher.attempt(provider: provider, artist: nil, album: "Test", inputFile: nil)
+        XCTAssertEqual(result.status, .success)
+        XCTAssertEqual(result.sizeBytes, data.count)
+    }
+}
+
 // MARK: - ProviderResult Tests
 
 final class ProviderResultTests: XCTestCase {


### PR DESCRIPTION
## 背景

Issue #52：`AlbumArtFetcher.attempt()` 使用 `withThrowingTaskGroup(of: Data?.self)`。

当 provider 返回 `nil`（"此来源没有封面，不是错误"）时，原实现的问题：
- `for try await result in group` 收到 `nil` 后继续循环
- timeout 任务仍在运行
- 最终 timeout 触发 → `throw TimeoutError()` → 被 catch 记成 `.error`
- 而非正确的 `.notFound`

## 修改内容

### AlbumArtFetcher.attempt()

元素类型从 `Data?.self` 改为 `Result<Data?, Error>.self`：

| Provider 结果 | 原来的行为 | 修复后的行为 |
|--------------|-----------|-------------|
| 返回 Data | ✅ `.success` | ✅ `.success` |
| 返回 nil | ❌ 等待 timeout → `.error` | ✅ `.success(nil)` → `.notFound` |
| 抛错 | ✅ `.error` | ✅ `.failure` → `.error` |

```swift
// Before: for try await result in group { if let d = result { return d } } return nil
// After:  guard let r = try await group.next() else { return .success(nil) }
```

`attempt()` 从 `private` 改为 `internal` 以支持直接单元测试。

### 新增测试（AlbumArtFetcherAttemptTests）

- `testProviderReturningNilGivesNotFound` — provider 返回 nil → `.notFound`
- `testProviderThrowingGivesError` — provider 抛错 → `.error`
- `testProviderReturningDataGivesSuccess` — provider 返回数据 → `.success`

## 验证

- `swift build` ✅
- `swift test` ✅（108 tests 全绿）
