### PR TITLE
fix: make split options page usable at default window size

### DIFF
--- a/GUI/App/TrackSplitterApp.swift
+++ b/GUI/App/TrackSplitterApp.swift
@@ -36,7 +36,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             defer: false
         )
         window.title = "TrackSplitter"
-        window.minSize = NSSize(width: 640, height: 480)
+        window.minSize = NSSize(width: 640, height: 560)
         window.backgroundColor = .windowBackgroundColor
         window.contentViewController = hostingController  // 用 contentViewController 而非直接设置 contentView
         window.center()

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
                 }
             }
         }
-        .frame(minWidth: 640, minHeight: 480)
+        .frame(minWidth: 640, minHeight: 560)
         .onReceive(NotificationCenter.default.publisher(for: .didSelectFlacFile)) { notification in
             if let url = notification.object as? URL {
                 viewModel.load(audioURL: url)
@@ -78,7 +78,7 @@ final class IdleViewController: NSViewController {
     private var dropZoneView: DropZoneVisualView!
 
     override func loadView() {
-        self.view = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        self.view = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 560))
         self.view.wantsLayer = true
     }
 
@@ -304,7 +304,8 @@ struct LoadedView: View {
 
 
     var body: some View {
-        VStack(spacing: 0) {
+        ScrollView {
+            VStack(spacing: 0) {
             HStack(spacing: 16) {
                 Image(systemName: "music.note")
                     .font(.title2)
@@ -337,7 +338,7 @@ struct LoadedView: View {
             Divider()
 
             TrackListView(tracks: loaded.tracks)
-                .frame(maxHeight: .infinity)
+                .frame(maxHeight: 280)
 
             Divider()
 
@@ -469,7 +470,7 @@ struct LoadedView: View {
             .padding(20)
             .background(Color(nsColor: .controlBackgroundColor))
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
         .onChange(of: selectedChapterSourceType) { newValue in
             if !newValue.requiresFile {
                 // Switching to auto or embedded — clear any previously picked file


### PR DESCRIPTION
## Summary

Fix the Loaded / "分割选项" page so it remains usable at the default window size instead of clipping the bottom options and primary action button.

## Changes

- wrap the LoadedView content in a vertical `ScrollView`
- cap the track list height so it no longer greedily consumes all remaining vertical space
- raise the default/minimum window height from `480` to `560`

## Why this fix

Previously, `TrackListView` used `maxHeight: .infinity`, which caused the loaded page to over-expand vertically and push the bottom configuration bar off-screen. Users had to manually resize the window to access the bottom controls.

This PR keeps scope tight:
- no broad UI redesign
- no changes to processing flow
- no changes outside the loaded/split-options page and window sizing

## Self-check

- built locally with `swift build --configuration release`
- verified the fix is focused to the loaded page path
- bottom options + primary action are reachable at default window size due to vertical scrolling + taller default/min window
