### PR TITLE
fix(Package): exclude Version.swift.in to eliminate SwiftPM warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,12 @@ let package = Package(
             name: "TrackSplitterLib",
             dependencies: [],
             path: "Library",
-            // embed_metadata.py is a resource, not a Swift source — include it explicitly.
+            // .swift.in template files are not compiled directly; they are processed
+            // at build time by a script (see Scripts/inject_version.sh). Exclude the
+            // template so SwiftPM stops flagging it as an "unhandled file".
+            exclude: ["Version.swift.in"],
+            // embed_metadata.py is needed at runtime; declared as a resource so it
+            // is included inside the built product.
             resources: [
                 .copy("Resources/embed_metadata.py")
             ]


### PR DESCRIPTION
## Summary
Fixes the SwiftPM "unhandled file(s)" warning by excluding `Library/Version.swift.in` from the TrackSplitterLib target.

`Version.swift.in` is a `.swift.in` template file processed at build time by `Scripts/inject_version.sh` — it is never compiled directly. SwiftPM was flagging it as an unhandled file because `.in` templates are not valid Swift sources and were not declared as resources or excluded.

## Changes
- **Package.swift**: Add `exclude: ["Version.swift.in"]` to the TrackSplitterLib target

## What this does NOT change
- No runtime behavior changes
- The `MetadataEmbedder.locateScript()` function is untouched; `Bundle.module` handling is left as-is

## Acceptance Criteria
- [x] `swift build` produces zero SwiftPM warnings
- [x] Version injection script (`Scripts/inject_version.sh`) still works correctly at release build time

Closes #18 (warning portion only).