### PR TITLE
fix: allow loading audio without CUE sheet (issue #72)

### DIFF
--- a/GUI/ViewModels/SplitterViewModel.swift
+++ b/GUI/ViewModels/SplitterViewModel.swift
@@ -138,13 +138,14 @@ final class SplitterViewModel: ObservableObject {
 
     struct LoadedFiles: Equatable {
         let audioURL: URL
-        let cueURL: URL
+        let cueURL: URL?
+        let cueParseFailed: Bool
         let tracks: [CueTrack]
         let albumTitle: String?
         let performer: String?
 
         static func == (lhs: LoadedFiles, rhs: LoadedFiles) -> Bool {
-            lhs.audioURL == rhs.audioURL && lhs.cueURL == rhs.cueURL
+            lhs.audioURL == rhs.audioURL && lhs.cueURL == rhs.cueURL && lhs.cueParseFailed == rhs.cueParseFailed
         }
     }
 
@@ -288,37 +289,73 @@ else:
             return
         }
 
-        guard let cueURL = findCue(for: audioURL) else {
-            log("FAIL: CUE not found")
-            setError("未找到匹配的 CUE 文件（请确认 CUE 中 FILE 字段与音频文件名一致）")
-            return
+        if let cueURL = findCue(for: audioURL) {
+            do {
+                let (tracks, albumTitle, performer, _, _) = try parseCue(at: cueURL)
+                log("CUE parsed: \(tracks.count) tracks")
+                let previewTracks = fillPreviewEndTimes(for: tracks)
+                let loaded = LoadedFiles(
+                    audioURL: audioURL,
+                    cueURL: cueURL,
+                    cueParseFailed: false,
+                    tracks: previewTracks,
+                    albumTitle: albumTitle,
+                    performer: performer
+                )
+                phase = .loaded(loaded)
+                logs = []
+                progress = 0
+                log("DONE: phase = .loaded (with CUE)")
+                return
+            } catch {
+                log("WARN: CUE exists but parse failed: \(error), continuing without CUE")
+                let loaded = LoadedFiles(
+                    audioURL: audioURL,
+                    cueURL: cueURL,
+                    cueParseFailed: true,
+                    tracks: [],
+                    albumTitle: nil,
+                    performer: nil
+                )
+                phase = .loaded(loaded)
+                logs = []
+                progress = 0
+                log("DONE: phase = .loaded (CUE parse failed)")
+                return
+            }
+        } else {
+            log("INFO: No CUE found, loading without chapter data")
         }
 
-        do {
-            let (tracks, albumTitle, performer, _, _) = try parseCue(at: cueURL)
-            log("CUE parsed: \(tracks.count) tracks")
-            let previewTracks = fillPreviewEndTimes(for: tracks)
-            let loaded = LoadedFiles(
-                audioURL: audioURL,
-                cueURL: cueURL,
-                tracks: previewTracks,
-                albumTitle: albumTitle,
-                performer: performer
-            )
-            phase = .loaded(loaded)
-            logs = []
-            progress = 0
-            log("DONE: phase = .loaded")
-        } catch {
-            log("FAIL: parseCue threw: \(error)")
-            setError("解析 CUE 失败：\(error.localizedDescription)")
-        }
+        let loaded = LoadedFiles(
+            audioURL: audioURL,
+            cueURL: nil,
+            cueParseFailed: false,
+            tracks: [],
+            albumTitle: nil,
+            performer: nil
+        )
+        phase = .loaded(loaded)
+        logs = []
+        progress = 0
+        log("DONE: phase = .loaded (no CUE)")
     }
 
     func startProcessing() {
         guard case .loaded(let loaded) = phase else {
             setError("当前没有可处理的文件")
             return
+        }
+
+        if selectedChapterSourceType == .auto {
+            if loaded.cueURL == nil {
+                setError("自动检测 CUE 失败：未找到匹配的 CUE 文件（请确认 CUE 中 FILE 字段与音频文件名一致），或手动选择其他章节来源")
+                return
+            }
+            if loaded.cueParseFailed {
+                setError("自动检测 CUE 失败：CUE 文件存在但解析失败（请检查 CUE 格式是否正确，或手动选择其他章节来源）")
+                return
+            }
         }
 
         logs = []

--- a/GUI/Views/ContentView.swift
+++ b/GUI/Views/ContentView.swift
@@ -301,7 +301,49 @@ struct LoadedView: View {
 
     @State private var isShowingDirectoryPicker = false
 
+    private var trackCountBadgeText: String {
+        if !loaded.tracks.isEmpty {
+            return "\(loaded.tracks.count) 曲目"
+        }
+        if loaded.cueParseFailed {
+            return "CUE 解析失败"
+        }
+        if loaded.cueURL != nil {
+            return "0 曲目"
+        }
+        switch selectedChapterSourceType {
+        case .auto:
+            return "未匹配到 CUE"
+        case .embedded:
+            return "嵌入章节"
+        case .cue, .textChapters, .ffmpegChapters:
+            return chapterSourceURL != nil ? "将读取章节" : "未选择文件"
+        }
+    }
 
+    private var trackListPlaceholderText: String {
+        if !loaded.tracks.isEmpty {
+            return ""
+        }
+        if loaded.cueParseFailed {
+            return "CUE 文件存在但解析失败，请检查 CUE 格式或选择其他章节来源"
+        }
+        if loaded.cueURL != nil {
+            return "无法解析 CUE 中的曲目"
+        }
+        switch selectedChapterSourceType {
+        case .auto:
+            return "请选择其他章节来源，或手动指定 CUE/章节文件"
+        case .embedded:
+            return "章节信息将在处理时从音频文件读取"
+        case .cue:
+            return chapterSourceURL != nil ? "将通过 CUE 文件读取章节" : "请选择 CUE 文件"
+        case .textChapters:
+            return chapterSourceURL != nil ? "将通过文本文件读取章节" : "请选择文本章节文件"
+        case .ffmpegChapters:
+            return chapterSourceURL != nil ? "将通过 FFmpeg 章节文件读取" : "请选择 FFmpeg 章节文件"
+        }
+    }
 
     var body: some View {
         ScrollView {
@@ -324,7 +366,7 @@ struct LoadedView: View {
 
                 Spacer()
 
-                Text("\(loaded.tracks.count) 曲目")
+                Text(trackCountBadgeText)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 12)
@@ -338,7 +380,14 @@ struct LoadedView: View {
             Divider()
 
             TrackListView(tracks: loaded.tracks)
-                .frame(maxHeight: 280)
+                .frame(maxHeight: loaded.tracks.isEmpty ? 100 : 280)
+                .overlay(alignment: .center) {
+                    if loaded.tracks.isEmpty {
+                        Text(trackListPlaceholderText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
 
             Divider()
 


### PR DESCRIPTION
## Summary

修复 GUI 在加载阶段强依赖 CUE 的问题，使 embedded / text / ffmetadata 章节模式可用。

### 改动

- cueURL 改为可选
- load() 不再强制要求 CUE，无 CUE 时也能进入 loaded 状态
- startProcessing() 新增检查：auto 模式但无 CUE 时给出清晰错误提示
- ContentView 新增 contextual placeholder：tracks 为空时显示操作提示

### 验收标准

- 无 CUE 的音频文件可在 GUI 中加载
- 用户可切换到 embedded/text/ffmetadata/手动 CUE 模式
- auto 模式在无 CUE 时给出清晰报错
- 108 个测试全部通过

Fixes #72