### PR TITLE
fix: correct embed_metadata.py path in XcodeGen (issue #73)

### DIFF
--- a/GUI/project.yml
+++ b/GUI/project.yml
@@ -34,7 +34,7 @@ targets:
     postBuildScripts:
       - name: Copy embed_metadata.py
         script: |
-          cp "${PROJECT_DIR}/../Resources/embed_metadata.py" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Resources/"
+          cp "${PROJECT_DIR}/../Library/Resources/embed_metadata.py" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Resources/"
         basedOnDependencyAnalysis: false
     settings:
       base:


### PR DESCRIPTION
## Summary

修复 `GUI/project.yml` 中 `embed_metadata.py` 的复制路径错误。

### 问题

post-build script 引用的是 `../Resources/embed_metadata.py`，但实际路径是 `../Library/Resources/embed_metadata.py`。仓库根目录下并不存在 `Resources/` 目录。

这意味着 GUI 打包后运行时找不到 `embed_metadata.py`，导致 metadata 写入功能失效。

### 修复

将 `project.yml` 中的路径修正为正确值。

### 验证

- 确认仓库根目录不存在 `Resources/` 目录
- 确认 `Library/Resources/embed_metadata.py` 存在

Fixes #73