### PR TITLE
release: add post-build validation before packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print :CFBundleVersion" GUI/App/Info.plist
 
       - name: Build GUI app
+        # Note: Currently builds arm64-only. Universal build support tracked in follow-up issue.
         run: |
           xcodebuild -project GUI/TrackSplitter.xcodeproj \
             -scheme TrackSplitter \
@@ -46,6 +47,51 @@ jobs:
             ARCHS="arm64" \
             ONLY_ACTIVE_ARCH=NO \
             build
+
+      - name: Validate build artifact
+        run: |
+          set -e
+
+          APP_PATH="DerivedData/Build/Products/Release/TrackSplitter.app"
+
+          if [ ! -d "$APP_PATH" ]; then
+            echo "ERROR: $APP_PATH does not exist"
+            exit 1
+          fi
+
+          if [ ! -f "$APP_PATH/Contents/Info.plist" ]; then
+            echo "ERROR: $APP_PATH/Contents/Info.plist does not exist"
+            exit 1
+          fi
+
+          EXEC_PATH="$APP_PATH/Contents/MacOS/TrackSplitter"
+          if [ ! -f "$EXEC_PATH" ]; then
+            echo "ERROR: $EXEC_PATH does not exist"
+            exit 1
+          fi
+          if [ ! -x "$EXEC_PATH" ]; then
+            echo "ERROR: $EXEC_PATH is not executable"
+            exit 1
+          fi
+
+          if [ ! -f "$APP_PATH/Contents/Resources/embed_metadata.py" ]; then
+            echo "ERROR: $APP_PATH/Contents/Resources/embed_metadata.py does not exist"
+            exit 1
+          fi
+
+          BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$APP_PATH/Contents/Info.plist" 2>/dev/null || echo "")
+          if [ -z "$BUNDLE_VERSION" ]; then
+            echo "ERROR: CFBundleVersion is empty or not set"
+            exit 1
+          fi
+          echo "CFBundleVersion: $BUNDLE_VERSION"
+
+          BUNDLE_SHORT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist" 2>/dev/null || echo "")
+          if [ -z "$BUNDLE_SHORT_VERSION" ]; then
+            echo "ERROR: CFBundleShortVersionString is empty or not set"
+            exit 1
+          fi
+          echo "CFBundleShortVersionString: $BUNDLE_SHORT_VERSION"
 
       - name: Package
         run: |
@@ -64,7 +110,7 @@ jobs:
 
             Built from tag `${{ github.ref_name }}`, build `${{ steps.build_num.outputs.build_num }}`.
 
-            **Requirements:** macOS 13.0 or later
+            **Requirements:** macOS 13.0 or later, Apple Silicon (arm64)
 
             **Install:**
             ```bash


### PR DESCRIPTION
## Summary

- Add `Validate build artifact` step to `.github/workflows/release.yml` that runs **before** packaging
- Checks the built `.app` has all critical components (Info.plist, executable, embed_metadata.py)
- Validates `CFBundleVersion` and `CFBundleShortVersionString` are non-empty via PlistBuddy
- Fails the workflow immediately if any check fails, preventing release of a broken artifact
- Clarify in workflow comment and release notes that this is an arm64-only build

## Validation checks

| Check | Reason |
|-------|--------|
| `TrackSplitter.app` directory exists | Build output exists |
| `Contents/Info.plist` exists | App bundle is valid |
| `Contents/MacOS/TrackSplitter` exists + executable | Main binary present and runnable |
| `Contents/Resources/embed_metadata.py` exists | Required resource present |
| `CFBundleVersion` non-empty | Version info populated |
| `CFBundleShortVersionString` non-empty | Version info populated |

## Out of scope (follow-up issues)

- Universal build (Intel + Apple Silicon)
- CLI artifact packaging

Fixes #76